### PR TITLE
chore(vercel): pin demo to 0.1.0-preview.0 + scope deploys to main

### DIFF
--- a/examples/express-app/package.json
+++ b/examples/express-app/package.json
@@ -8,10 +8,10 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@coraza/core": "workspace:*",
-    "@coraza/coreruleset": "workspace:*",
+    "@coraza/core": "0.1.0-preview.0",
+    "@coraza/coreruleset": "0.1.0-preview.0",
     "@coraza/example-shared": "workspace:*",
-    "@coraza/express": "workspace:*",
+    "@coraza/express": "0.1.0-preview.0",
     "express": "^5.0.0"
   },
   "devDependencies": {

--- a/examples/express-app/vercel.json
+++ b/examples/express-app/vercel.json
@@ -1,0 +1,9 @@
+{
+  "git": {
+    "deploymentEnabled": {
+      "main": true,
+      "develop": false
+    }
+  },
+  "ignoreCommand": "cd $(git rev-parse --show-toplevel) && git diff --quiet HEAD^ HEAD -- examples/express-app examples/shared packages/express packages/core packages/coreruleset wasm pnpm-lock.yaml pnpm-workspace.yaml turbo.json"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,17 +45,17 @@ importers:
   examples/express-app:
     dependencies:
       '@coraza/core':
-        specifier: workspace:*
-        version: link:../../packages/core
+        specifier: 0.1.0-preview.0
+        version: 0.1.0-preview.0
       '@coraza/coreruleset':
-        specifier: workspace:*
-        version: link:../../packages/coreruleset
+        specifier: 0.1.0-preview.0
+        version: 0.1.0-preview.0
       '@coraza/example-shared':
         specifier: workspace:*
         version: link:../shared
       '@coraza/express':
-        specifier: workspace:*
-        version: link:../../packages/express
+        specifier: 0.1.0-preview.0
+        version: 0.1.0-preview.0(express@5.2.1)
       express:
         specifier: ^5.0.0
         version: 5.2.1
@@ -441,6 +441,20 @@ packages:
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
+
+  '@coraza/core@0.1.0-preview.0':
+    resolution: {integrity: sha512-bCtkckihgJi6lKKg62CE+XRuMc3FBgwPGvM+4jK3q5vOuBLfyFlYrX0EAw2u8ba1gPbboPyXQbse5EyN62Eanw==}
+    engines: {node: '>=22'}
+
+  '@coraza/coreruleset@0.1.0-preview.0':
+    resolution: {integrity: sha512-q1/gmJ/C7Cafth9PE5ZTk5kiJctKrnipxLKCO/+MLEukDPpuYK8YGKV8HqVkeGQeH34N8hkNcCoiAcswjs4agA==}
+    engines: {node: '>=22'}
+
+  '@coraza/express@0.1.0-preview.0':
+    resolution: {integrity: sha512-jptTP3T7Y+yj1x0Cbad+D4hkXzFSHLqL/1ImVKglT581UD9CBceis3eIUFhLMeq4Osvn7UOUb8NGyRJ1Im6vGA==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      express: ^4.19.0 || ^5.0.0
 
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
@@ -2997,6 +3011,15 @@ snapshots:
 
   '@colors/colors@1.5.0':
     optional: true
+
+  '@coraza/core@0.1.0-preview.0': {}
+
+  '@coraza/coreruleset@0.1.0-preview.0': {}
+
+  '@coraza/express@0.1.0-preview.0(express@5.2.1)':
+    dependencies:
+      '@coraza/core': 0.1.0-preview.0
+      express: 5.2.1
 
   '@emnapi/runtime@1.10.0':
     dependencies:


### PR DESCRIPTION
## Summary
- Pin `examples/express-app` deps on `@coraza/core`, `@coraza/coreruleset`, `@coraza/express` to `0.1.0-preview.0` (exact pin), so the Vercel demo deploys what a real consumer installs. `example-shared` stays `workspace:*` (private, not published).
- Add `examples/express-app/vercel.json`:
  - `git.deploymentEnabled` restricts Vercel Git deploys to `main` (no PR previews, no develop builds).
  - `ignoreCommand` skips the build when the commit doesn't touch any path the demo depends on: `examples/express-app`, `examples/shared`, `packages/express`, `packages/core`, `packages/coreruleset`, `wasm`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `turbo.json`.

## Test plan
- [x] `pnpm install --frozen-lockfile` — clean
- [x] `pnpm -F @coraza/example-express typecheck` — passes
- [ ] Merge to main; next Vercel build log shows `@coraza/core@0.1.0-preview.0` resolved
- [ ] A main commit outside the listed paths triggers "build skipped" via `ignoreCommand`

🤖 Generated with [Claude Code](https://claude.com/claude-code)