### PR TITLE
fix(next): address issue #8 integration papercuts

### DIFF
--- a/.changeset/core-pool-mjs-worker-ready-timeout.md
+++ b/.changeset/core-pool-mjs-worker-ready-timeout.md
@@ -1,0 +1,20 @@
+---
+'@coraza/core': minor
+---
+
+`WAFPool`: ship the worker file as `pool-worker.mjs` so Node unambiguously
+loads it as ESM regardless of what the surrounding bundler does with
+`package.json` markers. Fixes a silent hang under Next.js 16 Turbopack
+dev mode where the emitted worker was `.js` with ESM `import` statements
+but no sibling `"type":"module"` — Node refused to load it, the worker
+never signalled ready, and `createWAFPool` awaited forever
+(github.com/jptosso/coraza-node#8).
+
+Also adds a `readyTimeoutMs` option to `createWAFPool` (default `10000`
+ms): if every worker has not acknowledged the init handshake within the
+window, the promise rejects with an actionable error that names the
+likely bundler / module-format cause. No more hang-forever.
+
+Public shape: `pool-worker.js` is no longer emitted — adapter callers
+never reference it directly, but any external tooling that expected
+`@coraza/core/dist/pool-worker.js` should switch to `pool-worker.mjs`.

--- a/.changeset/next-compose-runner.md
+++ b/.changeset/next-compose-runner.md
@@ -1,0 +1,14 @@
+---
+'@coraza/next': minor
+---
+
+Add `createCorazaRunner` — a factory returning a WAF evaluator with a
+structured decision (`{ blocked: Response } | { allow: true }`) so apps
+with an existing `proxy.ts` (auth, redirects, etc.) can compose Coraza
+with their own logic without sniffing the `x-middleware-next` response
+header (internal territory). See the "Composing with an existing
+`proxy.ts`" section of the adapter README for the canonical pattern.
+
+The existing `coraza(opts)` middleware helper is now a thin wrapper
+around `createCorazaRunner` and keeps its previous signature and
+behaviour.

--- a/.changeset/next-readme-next16.md
+++ b/.changeset/next-readme-next16.md
@@ -1,0 +1,18 @@
+---
+'@coraza/next': patch
+---
+
+Docs: update the README for Next.js 16 and `src/` layout —
+
+- Drop `runtime: 'nodejs'` from the `config` export; Next 16 rejects the
+  option outright in `proxy.ts` (`The runtime config option is not
+  available in Proxy files`) and it's redundant on 14/15 because Node is
+  already the default.
+- Show both filenames side-by-side (`proxy.ts` on Next 16, `middleware.ts`
+  on 14/15) with a short note so the snippet is copy-pasteable on every
+  current major.
+- Add a "File location" paragraph warning that with a `src/` layout,
+  the adapter file **must** live at `src/proxy.ts` / `src/middleware.ts`
+  — a file at the repo root is silently ignored (Next emits no logs).
+- Document the Turbopack pool-worker hazard and point at the new
+  `readyTimeoutMs` fail-fast (see the `@coraza/core` changeset).

--- a/README.md
+++ b/README.md
@@ -78,10 +78,16 @@ under 50-VU mixed traffic. Detail + tuning knobs:
 
 ## Adapter caveat — Next.js
 
-Next's middleware runs on the **request boundary only**. Route Handlers
-own the `Response`, and Next's runtime doesn't expose the response body
-back to middleware — that's a Next architectural choice, not a WAF
-limitation. Consequence for coraza-node:
+Supported on Next.js 14, 15, and 16. See
+[`packages/next/README.md`](./packages/next/README.md) for the
+copy-pasteable `proxy.ts` (Next 16) / `middleware.ts` (Next 14/15)
+snippet, the `src/` layout note, and how to compose with an existing
+`proxy.ts`.
+
+Next's middleware / proxy runs on the **request boundary only**. Route
+Handlers own the `Response`, and Next's runtime doesn't expose the
+response body back to middleware — that's a Next architectural choice,
+not a WAF limitation. Consequence for coraza-node:
 
 - **Inbound rules fire as usual.** URI, headers, and body inspection
   (CRS phases 1 + 2) work identically to every other adapter.

--- a/packages/core/src/pool.ts
+++ b/packages/core/src/pool.ts
@@ -42,9 +42,37 @@ export interface WAFPoolOptions extends WAFConfig {
    * `Infinity` to disable rotation.
    */
   maxRequestsPerWorker?: number
+  /**
+   * Maximum time (ms) to wait for every worker to come online and ack the
+   * `init` handshake before `createWAFPool` rejects. Default: `10000`
+   * (10 s). Pass `0` or `Infinity` to disable (legacy hang-forever
+   * behaviour — not recommended).
+   *
+   * Why this exists: some bundlers (e.g. Turbopack in Next.js 16 dev
+   * mode) emit the worker file with ESM `import` syntax but without a
+   * sibling `"type": "module"` marker and without a `.mjs` extension, so
+   * Node refuses to load it. The worker never emits `online`, `error`,
+   * or `exit`, and `createWAFPool` would otherwise await forever. This
+   * timeout converts that silent hang into a loud, actionable error
+   * that names the likely culprit.
+   */
+  readyTimeoutMs?: number
 }
 
 const DEFAULT_MAX_REQUESTS_PER_WORKER = 50_000
+
+/**
+ * How long to wait for every worker to come `online` and ack its `init`
+ * message before we reject `createWAFPool` with an actionable error. The
+ * pool normally boots in ~100-300 ms on a modern box; 10 s is well past
+ * that for any realistic machine while still tripping fast enough that
+ * an adapter's own timeout (e.g. Express' default 2-minute socket
+ * timeout) doesn't hide the failure. Exposed as an option for CI / slow
+ * containers that legitimately need longer (or `0` / `Infinity` to
+ * disable — never recommended; a hung pool is indistinguishable from a
+ * bundler that emitted the worker with the wrong module format).
+ */
+const DEFAULT_POOL_READY_TIMEOUT_MS = 10_000
 
 interface Pending {
   resolve(value: unknown): void
@@ -107,7 +135,7 @@ export class WAFPool {
   }
 
   static async create(opts: WAFPoolOptions): Promise<WAFPool> {
-    const { size: requested, maxRequestsPerWorker, ...config } = opts
+    const { size: requested, maxRequestsPerWorker, readyTimeoutMs, ...config } = opts
     const size = Math.max(1, requested ?? defaultSize())
     const logger = config.logger ?? consoleLogger
     const mode = config.mode ?? 'detect'
@@ -117,6 +145,12 @@ export class WAFPool {
         : maxRequestsPerWorker === 0 || !Number.isFinite(maxRequestsPerWorker)
           ? Infinity
           : Math.max(1, Math.floor(maxRequestsPerWorker))
+    const readyTimeout =
+      readyTimeoutMs === undefined
+        ? DEFAULT_POOL_READY_TIMEOUT_MS
+        : readyTimeoutMs === 0 || !Number.isFinite(readyTimeoutMs)
+          ? Infinity
+          : Math.max(1, Math.floor(readyTimeoutMs))
 
     // Compile the WASM module once on the main thread and share it with
     // every worker via workerData (structured clone preserves the compiled
@@ -142,11 +176,47 @@ export class WAFPool {
     for (let i = 0; i < size; i++) slots.push(spawnSlot(logger, wasmModule))
 
     // Init every worker in parallel, reject fast if any fails.
-    await Promise.all(
-      slots.map((slot) =>
-        slot.ready.then(() => callSlot<void>(slot, { type: 'init', config: workerConfig })),
-      ),
-    )
+    //
+    // Wrapped in a hard deadline: if a bundler has emitted the worker file
+    // with ESM syntax but without an ESM marker (no `.mjs` extension and
+    // no sibling `"type": "module"`), Node fails to load it silently —
+    // the worker never emits `online`, `error`, or `exit`, and
+    // `slot.ready` hangs forever. Turbopack in Next.js 16 dev mode is the
+    // canonical repro; see github.com/jptosso/coraza-node#8. Convert the
+    // hang into a loud error that tells the operator what to check.
+    try {
+      await withTimeout(
+        Promise.all(
+          slots.map((slot) =>
+            slot.ready.then(() => callSlot<void>(slot, { type: 'init', config: workerConfig })),
+          ),
+        ),
+        readyTimeout,
+        () =>
+          new Error(
+            `coraza: pool workers failed to initialize within ${readyTimeout}ms. ` +
+              `This usually means the bundler emitted the pool worker without an ESM marker ` +
+              `(Node needs either a .mjs extension or a sibling package.json with ` +
+              `"type":"module"). Known culprit: Next.js 16 Turbopack dev mode. ` +
+              `Workaround: use createWAF (single-threaded) or a bundler-specific opt-out. ` +
+              `Pass readyTimeoutMs to override this deadline.`,
+          ),
+      )
+    } catch (err) {
+      // Tear down any workers we did manage to spawn — otherwise they'd
+      // keep the event loop alive after the caller's `createWAFPool`
+      // promise rejects.
+      await Promise.allSettled(
+        slots.map(async (slot) => {
+          try {
+            await slot.worker.terminate()
+          } catch {
+            /* ignore */
+          }
+        }),
+      )
+      throw err
+    }
 
     const pool = new WAFPool(slots, logger, mode, workerConfig, maxReqs, wasmModule)
 
@@ -484,11 +554,38 @@ function defaultSize(): number {
     : os.cpus().length
 }
 
+async function withTimeout<T>(
+  p: Promise<T>,
+  ms: number,
+  mkErr: () => Error,
+): Promise<T> {
+  if (!Number.isFinite(ms)) return p
+  let timer: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      p,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(mkErr()), ms)
+        // Don't keep the event loop alive just for this watchdog; if the
+        // pool promise is going to resolve, the timer is redundant.
+        if (typeof (timer as unknown as { unref?: () => void }).unref === 'function') {
+          ;(timer as unknown as { unref: () => void }).unref()
+        }
+      }),
+    ])
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+}
+
 function spawnSlot(logger: Logger, wasmModule?: WebAssembly.Module): WorkerSlot {
-  const workerUrl = new URL('./pool-worker.js', import.meta.url)
+  // `.mjs` so Node treats the worker as ESM regardless of what the
+  // surrounding bundler (Turbopack, webpack, etc.) does with package.json
+  // markers. See github.com/jptosso/coraza-node#8.
+  const workerUrl = new URL('./pool-worker.mjs', import.meta.url)
   const worker = new Worker(fileURLToPath(workerUrl), {
     // Don't inherit the parent's loader args (e.g. --import tsx) — the worker
-    // runs the pre-compiled pool-worker.js and doesn't need the TS loader.
+    // runs the pre-compiled pool-worker.mjs and doesn't need the TS loader.
     execArgv: [],
     // Structured clone carries the compiled WebAssembly.Module by reference
     // so the worker skips its own compile step.

--- a/packages/core/test/pool-ready-timeout.test.ts
+++ b/packages/core/test/pool-ready-timeout.test.ts
@@ -1,0 +1,71 @@
+// Fail-fast guarantee for WAFPool worker bootstrap.
+//
+// Context: under Next.js 16 Turbopack dev mode, the bundler can emit the
+// pool worker file with ESM syntax but no sibling `"type": "module"`
+// marker. Node then refuses to load it — the worker never emits `online`,
+// `error`, or `exit`, and the old pool bootstrap would await forever.
+// That bug is what filed github.com/jptosso/coraza-node#8.
+//
+// We now cap the init handshake with `readyTimeoutMs` and reject with an
+// actionable error. This test proves the deadline fires and the error
+// names the likely culprit — we don't try to reproduce the Turbopack
+// repro (hard without an actual Next app); we just assert the defensive
+// timeout flips hangs into loud rejections.
+
+import { describe, it, expect } from 'vitest'
+import { existsSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+const distUrl = new URL('../dist/index.js', import.meta.url)
+const distPath = fileURLToPath(distUrl)
+const hasBuild = existsSync(distPath)
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let createWAFPool: any
+if (hasBuild) {
+  const mod = await import(distUrl.href)
+  createWAFPool = mod.createWAFPool
+}
+
+const describeIfBuilt = hasBuild ? describe : describe.skip
+
+describeIfBuilt('WAFPool ready timeout', () => {
+  it(
+    'rejects with an actionable error when workers do not init in time',
+    async () => {
+      // 1 ms is effectively impossible — even on a ramdisk, spawning a
+      // worker_thread + compiling/instantiating Coraza's WASM takes tens
+      // of ms. The rejection must carry a hint that names bundler/module
+      // format as the likely cause.
+      await expect(
+        createWAFPool({
+          rules: 'SecRuleEngine On\n',
+          size: 1,
+          mode: 'detect',
+          readyTimeoutMs: 1,
+        }),
+      ).rejects.toThrow(/failed to initialize within 1ms/i)
+    },
+    10_000,
+  )
+
+  it('surfaces the bundler / module-format hint in the error message', async () => {
+    // Explicitly check the copy — the hint is the reason this timeout
+    // exists; losing it silently would regress the UX we're trying to
+    // restore.
+    let caught: Error | null = null
+    try {
+      await createWAFPool({
+        rules: 'SecRuleEngine On\n',
+        size: 1,
+        mode: 'detect',
+        readyTimeoutMs: 1,
+      })
+    } catch (err) {
+      caught = err as Error
+    }
+    expect(caught).not.toBeNull()
+    expect(caught!.message).toMatch(/ESM marker|type":"module"|\.mjs/i)
+    expect(caught!.message).toMatch(/Turbopack|bundler/i)
+  })
+})

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -1,5 +1,13 @@
 import { defineConfig } from 'tsup'
-import { cpSync, mkdirSync } from 'node:fs'
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
 
 export default defineConfig({
   entry: ['src/index.ts', 'src/internal.ts', 'src/pool-worker.ts'],
@@ -12,5 +20,47 @@ export default defineConfig({
   async onSuccess() {
     mkdirSync('dist/wasm', { recursive: true })
     cpSync('src/wasm/coraza.wasm', 'dist/wasm/coraza.wasm')
+    // Rename the ESM worker output to `.mjs` so Node unambiguously treats
+    // it as ES module regardless of any bundler's `package.json` emission
+    // choices. Turbopack in Next.js 16 dev mode is the canonical case where
+    // `.js` would be re-emitted without a `"type":"module"` marker and fail
+    // to load. See github.com/jptosso/coraza-node#8. `pool.ts` references
+    // `./pool-worker.mjs` at runtime; keeping the rename in lock-step with
+    // that call site is what ships this fix.
+    const renames: Array<[string, string]> = [
+      ['dist/pool-worker.js', 'dist/pool-worker.mjs'],
+      ['dist/pool-worker.js.map', 'dist/pool-worker.mjs.map'],
+    ]
+    for (const [from, to] of renames) {
+      if (existsSync(from)) {
+        if (existsSync(to)) rmSync(to)
+        renameSync(from, to)
+      }
+    }
+    // Patch the sourceMappingURL inside the renamed worker so debugger /
+    // stack-trace tooling still finds the map.
+    const mjs = 'dist/pool-worker.mjs'
+    if (existsSync(mjs)) {
+      const src = readFileSync(mjs, 'utf8')
+      const patched = src.replace(
+        /\/\/# sourceMappingURL=pool-worker\.js\.map/g,
+        '//# sourceMappingURL=pool-worker.mjs.map',
+      )
+      if (patched !== src) writeFileSync(mjs, patched)
+    }
+    // Rewrite the `file` field inside the .map so DevTools doesn't complain.
+    const mjsMap = 'dist/pool-worker.mjs.map'
+    if (existsSync(mjsMap)) {
+      try {
+        const raw = readFileSync(mjsMap, 'utf8')
+        const parsed = JSON.parse(raw) as { file?: string }
+        if (parsed.file === 'pool-worker.js') {
+          parsed.file = 'pool-worker.mjs'
+          writeFileSync(mjsMap, JSON.stringify(parsed))
+        }
+      } catch {
+        /* map may be absent or minified; best-effort */
+      }
+    }
   },
 })

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -3,29 +3,98 @@
 Next.js middleware adapter for [coraza-node](https://github.com/jptosso/coraza-node).
 Node runtime only — the Edge runtime lacks WASI.
 
+## Quick start
+
 ```ts
-// middleware.ts
-import os from 'node:os'
-import { createWAFPool } from '@coraza/core'
+// Next 16+:   src/proxy.ts          (file renamed in Next 16)
+// Next 14/15: src/middleware.ts     (or middleware.ts at repo root)
+import { createWAF } from '@coraza/core'
 import { coraza } from '@coraza/next'
 import { recommended } from '@coraza/coreruleset'
 
-const waf = createWAFPool({
-  rules: recommended(),
-  mode: 'block',
-  size: os.availableParallelism(),
-})
+const waf = createWAF({ rules: recommended(), mode: 'block' })
 
-export const middleware = coraza({ waf })
-export const config = { matcher: '/:path*', runtime: 'nodejs' }
+// Pick the export name that matches your filename:
+//   `proxy.ts`      → export const proxy
+//   `middleware.ts` → export const middleware
+export const proxy = coraza({ waf })
+
+export const config = { matcher: '/:path*' }
 ```
+
+> **Next 16:** do **not** set `runtime: 'nodejs'` on the `config` export —
+> Next 16's `proxy.ts` defaults to the Node.js runtime and rejects the
+> option outright (`The runtime config option is not available in Proxy
+> files`). On Next 14/15 the option is accepted but also unnecessary
+> because Node is the default for `middleware.ts`.
+
+### File location (important with `src/` layout)
+
+With a `src/` directory, Next 16 **only** picks up `src/proxy.ts` — a
+file at the repo root is silently ignored and the adapter runs zero code
+(no logs). Mirror the convention of your `app/` directory:
+
+- `src/` layout → `src/proxy.ts` (or `src/middleware.ts` on 14/15)
+- Flat layout → `proxy.ts` at the project root
+
+### Threaded pool under Turbopack dev (Next 16)
+
+`createWAFPool` spawns `node:worker_threads` and loads a `.mjs` file for
+the worker body so Node always treats it as an ES module, regardless of
+what the bundler does around it. If the pool ever fails to come up, the
+`createWAFPool` promise rejects within `readyTimeoutMs` (default 10 s)
+with an actionable error — no more silent hangs.
+
+If you still hit bundler trouble, fall back to `createWAF`
+(single-threaded) — it works identically from the adapter's perspective:
+
+```ts
+const waf = createWAF({ rules: recommended(), mode: 'block' })
+export const proxy = coraza({ waf })
+```
+
+### Composing with an existing `proxy.ts`
+
+If your app already has a `proxy.ts` (auth gating, redirects, locale
+routing, etc.), use `createCorazaRunner` to get a structured decision
+back and fall through on allow:
+
+```ts
+// src/proxy.ts
+import { createWAF } from '@coraza/core'
+import { createCorazaRunner } from '@coraza/next'
+import { recommended } from '@coraza/coreruleset'
+import { NextResponse, type NextRequest } from 'next/server'
+
+const waf = createWAF({ rules: recommended(), mode: 'block' })
+const runCoraza = createCorazaRunner({ waf })
+
+export async function proxy(req: NextRequest) {
+  // 1. Coraza first — block attackers before any app code sees them.
+  const decision = await runCoraza(req)
+  if ('blocked' in decision) return decision.blocked
+
+  // 2. Your existing logic on allow.
+  if (!req.cookies.get('session')) {
+    return NextResponse.redirect(new URL('/login', req.url))
+  }
+  return NextResponse.next()
+}
+
+export const config = { matcher: '/:path*' }
+```
+
+`createCorazaRunner` returns `{ blocked: Response } | { allow: true }`.
+The `blocked` branch must be returned unchanged — post-processing a
+block defeats the WAF. This is the supported public API; sniffing
+`x-middleware-next` on a response is internal and not supported.
 
 ### Limitation — no response-body inspection
 
-Next middleware runs on the request boundary. Route Handlers own the
-`Response`, and Next's runtime doesn't hand the response body back to
-middleware, so CRS's `RESPONSE-95*-DATA-LEAKAGES-*` families can't fire
-on a Next deployment. Inbound protection (SQLi, XSS, RCE, LFI, RFI,
+Next middleware / proxy runs on the request boundary. Route Handlers own
+the `Response`, and Next's runtime doesn't hand the response body back
+to the proxy, so CRS's `RESPONSE-95*-DATA-LEAKAGES-*` families can't
+fire on a Next deployment. Inbound protection (SQLi, XSS, RCE, LFI, RFI,
 scanner-detection, protocol-attack, anomaly scoring) works identically
 to every other adapter. If you need response-body inspection, put
 Express or Fastify in front of Next and run coraza-node there.

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -26,7 +26,6 @@ import type {
   AnyWAF,
   WAFLike,
   Interruption,
-  Logger,
   SkipOptions,
 } from '@coraza/core'
 import { buildSkipPredicate } from '@coraza/core'
@@ -56,13 +55,43 @@ export interface CorazaNextOptions {
 }
 
 /**
- * Build a Next.js middleware. Matches the adapter shape used by the
- * other frameworks (`coraza({ waf, ...options })`) — pass a single
- * object with a `waf` key.
+ * Outcome returned by {@link createCorazaRunner}.
+ *
+ * - `{ blocked: Response }` — Coraza (or the configured `onWAFError`
+ *   policy) has produced a terminal response; the caller must return it
+ *   unchanged. Do NOT compose further proxy logic on top — returning a
+ *   "soft" response after a block defeats the WAF.
+ * - `{ allow: true }` — the request passed Coraza. The caller is free to
+ *   run its own `proxy.ts` logic (auth, redirects, header rewrites, etc.)
+ *   and then `NextResponse.next()` (or whatever it normally returns).
  */
-export function coraza(
+export type CorazaDecision = { blocked: Response } | { allow: true }
+
+/**
+ * Build a runner that evaluates a request through Coraza and returns a
+ * structured decision — intended for projects that already have a
+ * `proxy.ts` and want to compose Coraza with their existing logic
+ * (auth, redirects, etc.) without sniffing `x-middleware-next` headers.
+ *
+ * ```ts
+ * // proxy.ts
+ * import { createCorazaRunner } from '@coraza/next'
+ * const runCoraza = createCorazaRunner({ waf })
+ *
+ * export async function proxy(req: NextRequest) {
+ *   const decision = await runCoraza(req)
+ *   if ('blocked' in decision) return decision.blocked
+ *   // ...existing auth / redirect logic
+ *   return NextResponse.next()
+ * }
+ * ```
+ *
+ * The decision contract is stable public API; the `x-middleware-next`
+ * trick used previously is not.
+ */
+export function createCorazaRunner(
   options: CorazaNextOptions,
-): (req: NextRequest) => Promise<Response> {
+): (req: NextRequest) => Promise<CorazaDecision> {
   const { waf: wafOrPromise, onBlock = defaultBlock, onWAFError = 'block' } = options
   const shouldSkip = options.skip === false ? () => false : buildSkipPredicate(options.skip)
 
@@ -73,9 +102,9 @@ export function coraza(
     return wafRef
   }
 
-  return async function corazaMiddleware(req: NextRequest): Promise<Response> {
+  return async function runCoraza(req: NextRequest): Promise<CorazaDecision> {
     const url = new URL(req.url)
-    if (shouldSkip(url.pathname)) return NextResponse.next()
+    if (shouldSkip(url.pathname)) return { allow: true }
 
     const waf = await ensureWAF()
     const log = waf.logger
@@ -85,16 +114,19 @@ export function coraza(
       tx = await waf.newTransaction()
     } catch (err) {
       log.error('coraza: newTransaction failed', { err: (err as Error).message })
-      return onWAFError === 'block'
-        ? onBlock(
+      if (onWAFError === 'block') {
+        return {
+          blocked: onBlock(
             { ruleId: 0, action: 'deny', status: 503, data: 'WAF unavailable', source: 'waf-error' },
             req,
-          )
-        : NextResponse.next()
+          ),
+        }
+      }
+      return { allow: true }
     }
 
     try {
-      if (await tx.isRuleEngineOff()) return NextResponse.next()
+      if (await tx.isRuleEngineOff()) return { allow: true }
 
       // Read the body up front (Next streams it); the bundle needs it
       // to guarantee phase 2 runs.
@@ -111,18 +143,28 @@ export function coraza(
         body,
       )
       if (interrupted) {
-        return handleBlock(await tx.interruption(), req, onBlock, log)
+        const interruption = await tx.interruption()
+        if (!interruption) return { allow: true }
+        log.warn('coraza: request blocked', {
+          ruleId: interruption.ruleId,
+          status: interruption.status,
+          action: interruption.action,
+        })
+        return { blocked: onBlock(interruption, req) }
       }
 
-      return NextResponse.next()
+      return { allow: true }
     } catch (err) {
       log.error('coraza: middleware error', { err: (err as Error).message })
-      return onWAFError === 'block'
-        ? onBlock(
+      if (onWAFError === 'block') {
+        return {
+          blocked: onBlock(
             { ruleId: 0, action: 'deny', status: 503, data: 'WAF internal error', source: 'waf-error' },
             req,
-          )
-        : NextResponse.next()
+          ),
+        }
+      }
+      return { allow: true }
     } finally {
       try {
         await tx.processLogging()
@@ -130,6 +172,28 @@ export function coraza(
         await tx.close()
       }
     }
+  }
+}
+
+/**
+ * Build a Next.js middleware. Matches the adapter shape used by the
+ * other frameworks (`coraza({ waf, ...options })`) — pass a single
+ * object with a `waf` key.
+ *
+ * Thin wrapper around {@link createCorazaRunner} that returns a
+ * `NextResponse.next()` on allow. If you need to compose with existing
+ * proxy logic (auth, redirects, etc.), use `createCorazaRunner` directly
+ * so the decision stays structured and you don't have to sniff
+ * `x-middleware-next` on the response.
+ */
+export function coraza(
+  options: CorazaNextOptions,
+): (req: NextRequest) => Promise<Response> {
+  const run = createCorazaRunner(options)
+  return async function corazaMiddleware(req: NextRequest): Promise<Response> {
+    const decision = await run(req)
+    if ('blocked' in decision) return decision.blocked
+    return NextResponse.next()
   }
 }
 
@@ -141,21 +205,6 @@ export function defaultBlock(interruption: Interruption, _req: NextRequest): Res
       headers: { 'content-type': 'text/plain; charset=utf-8' },
     },
   )
-}
-
-function handleBlock(
-  interruption: Interruption | null,
-  req: NextRequest,
-  onBlock: NonNullable<CorazaNextOptions['onBlock']>,
-  log: Logger,
-): Response {
-  if (!interruption) return NextResponse.next()
-  log.warn('coraza: request blocked', {
-    ruleId: interruption.ruleId,
-    status: interruption.status,
-    action: interruption.action,
-  })
-  return onBlock(interruption, req)
 }
 
 function headersOf(h: Headers): [string, string][] {

--- a/packages/next/test/middleware.test.ts
+++ b/packages/next/test/middleware.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { NextRequest } from 'next/server'
-import { coraza, defaultBlock } from '../src/index.js'
+import { coraza, createCorazaRunner, defaultBlock } from '../src/index.js'
 import { mockWAF } from './helpers.js'
 
 function makeReq(url: string, init: RequestInit = {}): NextRequest {
@@ -220,5 +220,71 @@ describe('@coraza/next', () => {
     const mw = coraza({ waf })
     const res = await mw(makeReq('https://example.com/', { method: 'POST' }))
     expect(res.headers.get('x-middleware-next')).toBe('1')
+  })
+})
+
+// Compose-with-existing-proxy contract. The runner exposes a structured
+// decision so downstream `proxy.ts` code doesn't need to sniff
+// `x-middleware-next` on the response body — that sniff is internal
+// territory, see github.com/jptosso/coraza-node#8.
+describe('@coraza/next createCorazaRunner', () => {
+  it('returns { allow: true } on benign requests', async () => {
+    const { waf } = mockWAF('block')
+    const run = createCorazaRunner({ waf })
+    const decision = await run(makeReq('https://example.com/hi'))
+    expect(decision).toEqual({ allow: true })
+  })
+
+  it('returns { blocked } with the onBlock Response on an interruption', async () => {
+    const { waf } = mockWAF('block', {
+      onHeaders: () => ({ ruleId: 942100, action: 'deny', status: 403, data: 'SQLi' }),
+    })
+    const run = createCorazaRunner({ waf })
+    const decision = await run(makeReq('https://example.com/x?id=1%27OR%271'))
+    expect('blocked' in decision).toBe(true)
+    if (!('blocked' in decision)) return
+    expect(decision.blocked.status).toBe(403)
+    expect(await decision.blocked.text()).toContain('942100')
+  })
+
+  it('bypasses static paths (returns allow without a WAF call)', async () => {
+    const { waf, state } = mockWAF('block', {
+      onHeaders: () => ({ ruleId: 1, action: 'deny', status: 403, data: 'x' }),
+    })
+    const run = createCorazaRunner({ waf })
+    const decision = await run(makeReq('https://example.com/img/logo.png'))
+    expect(decision).toEqual({ allow: true })
+    expect(state.nextTx).toBe(0)
+  })
+
+  it('composes cleanly with existing proxy logic', async () => {
+    // Shape of the compose pattern we want to document in the README:
+    // run Coraza first, bail on block, otherwise fall through to auth.
+    // Interruption is URL-keyed so the same mock services both the
+    // "blocked" and "allowed" legs of the flow.
+    const { waf } = mockWAF('block', {
+      onHeaders: (tx) =>
+        tx.uri?.uri?.includes('OR')
+          ? { ruleId: 942100, action: 'deny', status: 403, data: 'SQLi' }
+          : undefined,
+    })
+    const run = createCorazaRunner({ waf })
+    async function proxy(req: NextRequest): Promise<Response> {
+      const decision = await run(req)
+      if ('blocked' in decision) return decision.blocked
+      // Pretend-auth: deny when no cookie is present.
+      if (!req.headers.get('cookie')) {
+        return new Response('Unauthorized', { status: 401 })
+      }
+      return new Response(null, { headers: { 'x-middleware-next': '1' } })
+    }
+    const blocked = await proxy(makeReq('https://example.com/x?id=1%27OR%271'))
+    expect(blocked.status).toBe(403)
+    const unauth = await proxy(makeReq('https://example.com/hi'))
+    expect(unauth.status).toBe(401)
+    const allowed = await proxy(
+      makeReq('https://example.com/hi', { headers: { cookie: 'session=abc' } }),
+    )
+    expect(allowed.headers.get('x-middleware-next')).toBe('1')
   })
 })


### PR DESCRIPTION
Closes items 1, 2, 4, 5 of #8. Item 3 (peer-dep range) was already fixed on `develop` by a7941a4.

## Items tied to the issue

### 1. `createWAFPool` hangs silently under Turbopack dev (Next 16)
Root cause: Turbopack re-emits `pool-worker.js` with ESM `import` syntax but without a sibling `"type":"module"` marker, so Node refuses to load it; the worker never signals ready/error/exit and `createWAFPool` awaits forever.

Defensive fixes (both ship together):
- **a.** `@coraza/core` now emits the pool worker as `pool-worker.mjs` and `pool.ts` references it via `new URL('./pool-worker.mjs', import.meta.url)`. Node treats `.mjs` as ESM unconditionally, no matter what the bundler does with `package.json`. The tsup `onSuccess` rename also patches `sourceMappingURL` and the map's `file` field so debuggers stay happy.
- **b.** New `WAFPoolOptions.readyTimeoutMs` (default `10000`). If any worker fails to online+init within the window, `createWAFPool` rejects with a message naming bundler/module format as the likely culprit (copy of the error in the `pool-ready-timeout` test). Hang-forever is gone; adapters' `onWAFError: 'block'` path is now actually reachable when workers can't boot.

Verified: `pnpm -F @coraza/core test` → **94/94 passing** (including 4 existing pool-rotation tests and 2 new `pool-ready-timeout` tests).

### 2. README examples broken on Next 16
`packages/next/README.md` rewritten (and the top-level `README.md` now links to it for the canonical snippet):
- Drop `runtime: 'nodejs'` — Next 16 throws on it in `proxy.ts`, and it's redundant on 14/15.
- Show both `proxy.ts` (Next 16) and `middleware.ts` (Next 14/15) filenames in one note, with matching `export const proxy = ` / `export const middleware = ` guidance.
- Keep the example minimal and copy-pasteable.

### 4. `proxy.ts` location with `src/` layout
Doc-only. Added a "File location (important with `src/` layout)" subsection that explicitly warns a repo-root `proxy.ts` is silently skipped under a `src/` layout — the adapter runs zero code and there's nothing to grep for.

### 5. Composing with an existing `proxy.ts`
New export: `createCorazaRunner(opts)` returns `(req) => Promise<{ blocked: Response } | { allow: true }>`. The existing `coraza()` middleware helper is now a thin wrapper around it; public contract unchanged.
- README adds a "Composing with an existing `proxy.ts`" section with a canonical auth-gating pattern.
- Explicit warning: return `decision.blocked` unchanged — post-processing a block defeats the WAF.
- No more `x-middleware-next` sniffing.

Verified: `pnpm -F @coraza/next test` → **22/22 passing** (4 new runner tests added).

## Tests run before push

- `pnpm -F @coraza/core test` → 94/94 passing
- `pnpm -F @coraza/next typecheck` → clean
- `pnpm -F @coraza/next test` → 22/22 passing
- `pnpm -F @coraza/next e2e` → 4/4 passing against Next 16 (`middleware` file convention deprecation warning surfaces but the adapter still works)

## Security impact

None net-negative. Item (1) removes a silent-failure availability hole: previously the adapter's `onWAFError: 'block'` path couldn't fire because the init promise never rejected. With the timeout, fail-closed actually runs. Items (2) and (4) are docs. Item (5) is additive; blocks still flow through the configured `onBlock` and the README is explicit that returning the `blocked` response unchanged is required.

## Changesets

- `@coraza/core` **minor** — `.mjs` worker + `readyTimeoutMs` (new option).
- `@coraza/next` **minor** — `createCorazaRunner` export.
- `@coraza/next` **patch** — README for Next 16 + `src/` layout.

## Not closing the issue

Per task direction, leaving #8 open for a maintainer to close on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)