### PR TITLE
chore: rename jptosso/coraza-node → coraza-incubator/coraza-node

### DIFF
--- a/.changeset/core-pool-mjs-worker-ready-timeout.md
+++ b/.changeset/core-pool-mjs-worker-ready-timeout.md
@@ -8,7 +8,7 @@ loads it as ESM regardless of what the surrounding bundler does with
 dev mode where the emitted worker was `.js` with ESM `import` statements
 but no sibling `"type":"module"` — Node refused to load it, the worker
 never signalled ready, and `createWAFPool` awaited forever
-(github.com/jptosso/coraza-node#8).
+(github.com/coraza-incubator/coraza-node#8).
 
 Also adds a `readyTimeoutMs` option to `createWAFPool` (default `10000`
 ms): if every worker has not acknowledged the init handshake within the

--- a/.changeset/core-pool-mjs-worker-ready-timeout.md
+++ b/.changeset/core-pool-mjs-worker-ready-timeout.md
@@ -1,5 +1,5 @@
 ---
-'@coraza/core': minor
+'@coraza/core': patch
 ---
 
 `WAFPool`: ship the worker file as `pool-worker.mjs` so Node unambiguously

--- a/.changeset/initial-preview.md
+++ b/.changeset/initial-preview.md
@@ -24,5 +24,5 @@ matrix (Node 22 + 24), SHA-pinned actions, weekly k6 regression
 bench. Known inbound-only adapters: Next and NestJS (framework
 limitations, documented).
 
-See README and https://jptosso.github.io/coraza-node for the full
+See README and https://coraza-incubator.github.io/coraza-node for the full
 guide.

--- a/.changeset/next-compose-runner.md
+++ b/.changeset/next-compose-runner.md
@@ -1,5 +1,5 @@
 ---
-'@coraza/next': minor
+'@coraza/next': patch
 ---
 
 Add `createCorazaRunner` — a factory returning a WAF evaluator with a

--- a/.changeset/org-transfer.md
+++ b/.changeset/org-transfer.md
@@ -1,0 +1,8 @@
+---
+---
+
+Repo transferred from `jptosso/coraza-node` to
+`coraza-incubator/coraza-node`. This PR updates every in-repo reference
+(package.json repo URLs, READMEs, source comments citing issue #8,
+docs site, wasm/go.mod module path, Pages URL). No code behavior
+changes and no version bump — empty changeset by design.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ to WebAssembly via TinyGo and embedded inside each framework adapter. The
 [OWASP CoreRuleSet](https://github.com/coreruleset/coreruleset) is baked into
 the WASM via [`coraza-coreruleset`](https://github.com/corazawaf/coraza-coreruleset).
 
-- Docs site: **[jptosso.github.io/coraza-node](https://jptosso.github.io/coraza-node)**
+- Docs site: **[coraza-incubator.github.io/coraza-node](https://coraza-incubator.github.io/coraza-node)**
 - Live Express demo on Vercel: **[coraza-node-express-app.vercel.app](https://coraza-node-express-app.vercel.app/)**
   (try `?q=%27+OR+1%3D1--` to see CRS block a SQLi payload)
 
@@ -59,7 +59,7 @@ lambdas, CLIs). For long-running HTTP servers, always use
 
 Full guide — tuning, custom block responses, fail-open/closed, detect-only
 mode, per-adapter options — lives on the docs site:
-**[jptosso.github.io/coraza-node](https://jptosso.github.io/coraza-node)**.
+**[coraza-incubator.github.io/coraza-node](https://coraza-incubator.github.io/coraza-node)**.
 
 ## Development
 
@@ -74,7 +74,7 @@ pnpm e2e           # end-to-end tests per adapter
 
 ~4,857 RPS under full CRS at POOL=8, 100% attack block rate, p99 ~37 ms
 under 50-VU mixed traffic. Detail + tuning knobs:
-**[jptosso.github.io/coraza-node#perf](https://jptosso.github.io/coraza-node#perf)**.
+**[coraza-incubator.github.io/coraza-node#perf](https://coraza-incubator.github.io/coraza-node#perf)**.
 
 ## Adapter caveat — Next.js
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ they represent a concrete risk.
 ## How to report
 
 **Use the GitHub Security Advisories tab.** Open a private advisory at
-<https://github.com/jptosso/coraza-node/security/advisories/new>. That's
+<https://github.com/coraza-incubator/coraza-node/security/advisories/new>. That's
 the only supported channel. Please do not:
 
 - Open a public issue for a vulnerability before an advisory is resolved.
@@ -82,7 +82,7 @@ In scope:
 Out of scope:
 
 - Example apps run in dev / detect mode on a laptop.
-- Docs site (<https://jptosso.github.io/coraza-node>).
+- Docs site (<https://coraza-incubator.github.io/coraza-node>).
 - The benchmark harnesses under `bench/`.
 - Dependencies' own advisories — see upstream.
 

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -30,7 +30,7 @@
       <a href="#quickstart" class="topnav-link">Docs</a>
       <a href="#api-core" class="topnav-link">API</a>
       <a href="#recipes" class="topnav-link">Recipes</a>
-      <a href="https://github.com/jptosso/coraza-node" class="topnav-link" rel="noopener">GitHub ↗</a>
+      <a href="https://github.com/coraza-incubator/coraza-node" class="topnav-link" rel="noopener">GitHub ↗</a>
     </nav>
 
     <div class="topbar-actions">
@@ -595,7 +595,7 @@ app.<span class="c-f">register</span>(<span class="c-k">async</span> (api) =&gt;
           <br><br>
           If you need response-body inspection, put Express or Fastify
           in front and run coraza-node there. Documented in
-          <a href="https://github.com/jptosso/coraza-node/blob/main/testing/ftw/ftw-overrides-next.yaml">ftw-overrides-next.yaml</a>
+          <a href="https://github.com/coraza-incubator/coraza-node/blob/main/testing/ftw/ftw-overrides-next.yaml">ftw-overrides-next.yaml</a>
           as the <code>[next-only]</code> go-ftw skips.
         </div>
       </div>
@@ -766,7 +766,7 @@ app.<span class="c-f">use</span>(<span class="c-f">coraza</span>({ waf, onWAFErr
         <div class="callout-badge">Known caveats</div>
         <div>
           Full threat model + caveats (ReDoS via V8 Irregexp, Unicode case-insensitive, UTF-8 encoding, rxprefilter accuracy) are in
-          <a href="https://github.com/jptosso/coraza-node/blob/main/docs/threat-model.md">docs/threat-model.md</a>.
+          <a href="https://github.com/coraza-incubator/coraza-node/blob/main/docs/threat-model.md">docs/threat-model.md</a>.
           Escape hatch: <code>CORAZA_HOST_RX=off</code> forces every <code>@rx</code> pattern through Go's linear-time regex
           instead of V8's backtracking engine.
         </div>
@@ -843,7 +843,7 @@ app.<span class="c-f">use</span>(<span class="c-f">coraza</span>({ waf, onWAFErr
         </div>
         <div class="foot-links">
           <a href="#overview">Top ↑</a>
-          <a href="https://github.com/jptosso/coraza-node" rel="noopener">GitHub</a>
+          <a href="https://github.com/coraza-incubator/coraza-node" rel="noopener">GitHub</a>
           <a href="https://coreruleset.org" rel="noopener">CRS</a>
         </div>
       </div>

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -143,7 +143,7 @@ that our port doesn't ship yet.
 **Follow-up**: port the rxprefilter tests and include them in our CI.
 Until then, treat any new rxprefilter behavior with suspicion; disable
 with a build-tag flag if a regression surfaces. File an issue at
-<https://github.com/jptosso/coraza-node/issues> if you hit a mismatch
+<https://github.com/coraza-incubator/coraza-node/issues> if you hit a mismatch
 against upstream behaviour.
 
 ## Audit checklist for new perf changes

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Juan Pablo Tosso <jptosso@gmail.com>",
   "repository": {
     "type": "git",
-    "url": "https://github.com/jptosso/coraza-node.git"
+    "url": "https://github.com/coraza-incubator/coraza-node.git"
   },
   "packageManager": "pnpm@9.12.0",
   "engines": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -21,7 +21,7 @@ skip?, inspectResponse? })`) and accept both a built WAF and a
   bench. Known inbound-only adapters: Next and NestJS (framework
   limitations, documented).
 
-  See README and https://jptosso.github.io/coraza-node for the full
+  See README and https://coraza-incubator.github.io/coraza-node for the full
   guide.
 
 - c8cdd9e: perf(core): tighten `env.rx_match` host import for V8 fast-call

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,6 +1,6 @@
 # @coraza/core
 
-Core WAF engine for [coraza-node](https://github.com/jptosso/coraza-node).
+Core WAF engine for [coraza-node](https://github.com/coraza-incubator/coraza-node).
 Loads the compiled OWASP Coraza WASM binary and exposes the
 `WAF` / `WAFPool` / `Transaction` primitives that every framework adapter
 builds on. Framework-agnostic — use one of the adapters
@@ -22,5 +22,5 @@ const waf = await createWAFPool({
 > **Experimental.** Independent community project, not an official
 > OWASP / Coraza release. API may change before 1.0.
 
-Docs: <https://jptosso.github.io/coraza-node>
+Docs: <https://coraza-incubator.github.io/coraza-node>
 · License: Apache-2.0

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,10 +4,10 @@
   "description": "Experimental community packaging of OWASP Coraza WAF for Node.js — core engine (WASM loader). Not an official Coraza/OWASP release.",
   "license": "Apache-2.0",
   "author": "Juan Pablo Tosso <jptosso@gmail.com>",
-  "homepage": "https://github.com/jptosso/coraza-node",
+  "homepage": "https://github.com/coraza-incubator/coraza-node",
   "repository": {
     "type": "git",
-    "url": "https://github.com/jptosso/coraza-node.git",
+    "url": "https://github.com/coraza-incubator/coraza-node.git",
     "directory": "packages/core"
   },
   "keywords": [

--- a/packages/core/src/pool.ts
+++ b/packages/core/src/pool.ts
@@ -182,7 +182,7 @@ export class WAFPool {
     // no sibling `"type": "module"`), Node fails to load it silently —
     // the worker never emits `online`, `error`, or `exit`, and
     // `slot.ready` hangs forever. Turbopack in Next.js 16 dev mode is the
-    // canonical repro; see github.com/jptosso/coraza-node#8. Convert the
+    // canonical repro; see github.com/coraza-incubator/coraza-node#8. Convert the
     // hang into a loud error that tells the operator what to check.
     try {
       await withTimeout(
@@ -581,7 +581,7 @@ async function withTimeout<T>(
 function spawnSlot(logger: Logger, wasmModule?: WebAssembly.Module): WorkerSlot {
   // `.mjs` so Node treats the worker as ESM regardless of what the
   // surrounding bundler (Turbopack, webpack, etc.) does with package.json
-  // markers. See github.com/jptosso/coraza-node#8.
+  // markers. See github.com/coraza-incubator/coraza-node#8.
   const workerUrl = new URL('./pool-worker.mjs', import.meta.url)
   const worker = new Worker(fileURLToPath(workerUrl), {
     // Don't inherit the parent's loader args (e.g. --import tsx) — the worker

--- a/packages/core/test/pool-ready-timeout.test.ts
+++ b/packages/core/test/pool-ready-timeout.test.ts
@@ -4,7 +4,7 @@
 // pool worker file with ESM syntax but no sibling `"type": "module"`
 // marker. Node then refuses to load it — the worker never emits `online`,
 // `error`, or `exit`, and the old pool bootstrap would await forever.
-// That bug is what filed github.com/jptosso/coraza-node#8.
+// That bug is what filed github.com/coraza-incubator/coraza-node#8.
 //
 // We now cap the init handshake with `readyTimeoutMs` and reject with an
 // actionable error. This test proves the deadline fires and the error

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
     // it as ES module regardless of any bundler's `package.json` emission
     // choices. Turbopack in Next.js 16 dev mode is the canonical case where
     // `.js` would be re-emitted without a `"type":"module"` marker and fail
-    // to load. See github.com/jptosso/coraza-node#8. `pool.ts` references
+    // to load. See github.com/coraza-incubator/coraza-node#8. `pool.ts` references
     // `./pool-worker.mjs` at runtime; keeping the rename in lock-step with
     // that call site is what ships this fix.
     const renames: Array<[string, string]> = [

--- a/packages/coreruleset/CHANGELOG.md
+++ b/packages/coreruleset/CHANGELOG.md
@@ -21,5 +21,5 @@ skip?, inspectResponse? })`) and accept both a built WAF and a
   bench. Known inbound-only adapters: Next and NestJS (framework
   limitations, documented).
 
-  See README and https://jptosso.github.io/coraza-node for the full
+  See README and https://coraza-incubator.github.io/coraza-node for the full
   guide.

--- a/packages/coreruleset/README.md
+++ b/packages/coreruleset/README.md
@@ -18,5 +18,5 @@ const rules = recommended({ paranoia: 1 })
 > **Experimental.** Independent community project, not an official
 > OWASP / Coraza release.
 
-Docs: <https://jptosso.github.io/coraza-node>
+Docs: <https://coraza-incubator.github.io/coraza-node>
 · License: Apache-2.0

--- a/packages/coreruleset/package.json
+++ b/packages/coreruleset/package.json
@@ -4,10 +4,10 @@
   "description": "OWASP CoreRuleSet config presets for @coraza/core. CRS rules ship inside the core WASM; this package selects which ones to enable.",
   "license": "Apache-2.0",
   "author": "Juan Pablo Tosso <jptosso@gmail.com>",
-  "homepage": "https://github.com/jptosso/coraza-node",
+  "homepage": "https://github.com/coraza-incubator/coraza-node",
   "repository": {
     "type": "git",
-    "url": "https://github.com/jptosso/coraza-node.git",
+    "url": "https://github.com/coraza-incubator/coraza-node.git",
     "directory": "packages/coreruleset"
   },
   "keywords": [

--- a/packages/express/CHANGELOG.md
+++ b/packages/express/CHANGELOG.md
@@ -21,7 +21,7 @@ skip?, inspectResponse? })`) and accept both a built WAF and a
   bench. Known inbound-only adapters: Next and NestJS (framework
   limitations, documented).
 
-  See README and https://jptosso.github.io/coraza-node for the full
+  See README and https://coraza-incubator.github.io/coraza-node for the full
   guide.
 
 ### Patch Changes

--- a/packages/express/README.md
+++ b/packages/express/README.md
@@ -1,6 +1,6 @@
 # @coraza/express
 
-Express middleware for [coraza-node](https://github.com/jptosso/coraza-node).
+Express middleware for [coraza-node](https://github.com/coraza-incubator/coraza-node).
 
 ```ts
 import os from 'node:os'
@@ -27,5 +27,5 @@ errors (override with `onWAFError: 'allow'`).
 > **Experimental.** Independent community project, not an official
 > OWASP / Coraza release.
 
-Docs: <https://jptosso.github.io/coraza-node#api-express>
+Docs: <https://coraza-incubator.github.io/coraza-node#api-express>
 · License: Apache-2.0

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -6,7 +6,7 @@
   "author": "Juan Pablo Tosso <jptosso@gmail.com>",
   "repository": {
     "type": "git",
-    "url": "https://github.com/jptosso/coraza-node.git",
+    "url": "https://github.com/coraza-incubator/coraza-node.git",
     "directory": "packages/express"
   },
   "keywords": [

--- a/packages/fastify/CHANGELOG.md
+++ b/packages/fastify/CHANGELOG.md
@@ -21,7 +21,7 @@ skip?, inspectResponse? })`) and accept both a built WAF and a
   bench. Known inbound-only adapters: Next and NestJS (framework
   limitations, documented).
 
-  See README and https://jptosso.github.io/coraza-node for the full
+  See README and https://coraza-incubator.github.io/coraza-node for the full
   guide.
 
 ### Patch Changes

--- a/packages/fastify/README.md
+++ b/packages/fastify/README.md
@@ -1,6 +1,6 @@
 # @coraza/fastify
 
-Fastify plugin for [coraza-node](https://github.com/jptosso/coraza-node).
+Fastify plugin for [coraza-node](https://github.com/coraza-incubator/coraza-node).
 
 ```ts
 import os from 'node:os'
@@ -25,5 +25,5 @@ adapters skip response inspection and log a warning.
 > **Experimental.** Independent community project, not an official
 > OWASP / Coraza release.
 
-Docs: <https://jptosso.github.io/coraza-node#api-fastify>
+Docs: <https://coraza-incubator.github.io/coraza-node#api-fastify>
 · License: Apache-2.0

--- a/packages/fastify/package.json
+++ b/packages/fastify/package.json
@@ -6,7 +6,7 @@
   "author": "Juan Pablo Tosso <jptosso@gmail.com>",
   "repository": {
     "type": "git",
-    "url": "https://github.com/jptosso/coraza-node.git",
+    "url": "https://github.com/coraza-incubator/coraza-node.git",
     "directory": "packages/fastify"
   },
   "keywords": [

--- a/packages/nestjs/CHANGELOG.md
+++ b/packages/nestjs/CHANGELOG.md
@@ -21,7 +21,7 @@ skip?, inspectResponse? })`) and accept both a built WAF and a
   bench. Known inbound-only adapters: Next and NestJS (framework
   limitations, documented).
 
-  See README and https://jptosso.github.io/coraza-node for the full
+  See README and https://coraza-incubator.github.io/coraza-node for the full
   guide.
 
 ### Patch Changes

--- a/packages/nestjs/README.md
+++ b/packages/nestjs/README.md
@@ -1,6 +1,6 @@
 # @coraza/nestjs
 
-NestJS module + guard for [coraza-node](https://github.com/jptosso/coraza-node).
+NestJS module + guard for [coraza-node](https://github.com/coraza-incubator/coraza-node).
 
 ```ts
 // app.module.ts
@@ -31,5 +31,5 @@ middleware limitation.
 > **Experimental.** Independent community project, not an official
 > OWASP / Coraza release.
 
-Docs: <https://jptosso.github.io/coraza-node#api-nestjs>
+Docs: <https://coraza-incubator.github.io/coraza-node#api-nestjs>
 · License: Apache-2.0

--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -6,7 +6,7 @@
   "author": "Juan Pablo Tosso <jptosso@gmail.com>",
   "repository": {
     "type": "git",
-    "url": "https://github.com/jptosso/coraza-node.git",
+    "url": "https://github.com/coraza-incubator/coraza-node.git",
     "directory": "packages/nestjs"
   },
   "keywords": [

--- a/packages/next/CHANGELOG.md
+++ b/packages/next/CHANGELOG.md
@@ -21,7 +21,7 @@ skip?, inspectResponse? })`) and accept both a built WAF and a
   bench. Known inbound-only adapters: Next and NestJS (framework
   limitations, documented).
 
-  See README and https://jptosso.github.io/coraza-node for the full
+  See README and https://coraza-incubator.github.io/coraza-node for the full
   guide.
 
 ### Patch Changes

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -1,6 +1,6 @@
 # @coraza/next
 
-Next.js middleware adapter for [coraza-node](https://github.com/jptosso/coraza-node).
+Next.js middleware adapter for [coraza-node](https://github.com/coraza-incubator/coraza-node).
 Node runtime only — the Edge runtime lacks WASI.
 
 ## Quick start
@@ -102,5 +102,5 @@ Express or Fastify in front of Next and run coraza-node there.
 > **Experimental.** Independent community project, not an official
 > OWASP / Coraza release.
 
-Docs: <https://jptosso.github.io/coraza-node#api-next>
+Docs: <https://coraza-incubator.github.io/coraza-node#api-next>
 · License: Apache-2.0

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -6,7 +6,7 @@
   "author": "Juan Pablo Tosso <jptosso@gmail.com>",
   "repository": {
     "type": "git",
-    "url": "https://github.com/jptosso/coraza-node.git",
+    "url": "https://github.com/coraza-incubator/coraza-node.git",
     "directory": "packages/next"
   },
   "keywords": [

--- a/packages/next/test/middleware.test.ts
+++ b/packages/next/test/middleware.test.ts
@@ -226,7 +226,7 @@ describe('@coraza/next', () => {
 // Compose-with-existing-proxy contract. The runner exposes a structured
 // decision so downstream `proxy.ts` code doesn't need to sniff
 // `x-middleware-next` on the response body — that sniff is internal
-// territory, see github.com/jptosso/coraza-node#8.
+// territory, see github.com/coraza-incubator/coraza-node#8.
 describe('@coraza/next createCorazaRunner', () => {
   it('returns { allow: true } on benign requests', async () => {
     const { waf } = mockWAF('block')

--- a/wasm/go.mod
+++ b/wasm/go.mod
@@ -1,4 +1,4 @@
-module github.com/jptosso/coraza-node/wasm
+module github.com/coraza-incubator/coraza-node/wasm
 
 go 1.26.0
 


### PR DESCRIPTION
## Summary
Repo is now under the \`coraza-incubator\` GitHub org. This PR updates every in-repo reference to the old \`jptosso/coraza-node\` slug:

- \`package.json\` \`repository.url\` / \`homepage\` (root + 6 packages)
- Adapter READMEs, SECURITY.md, docs/threat-model.md
- Changesets and CHANGELOG entries
- \`docs/site/index.html\` nav + content links
- Issue-8 references embedded in source + tests (\`packages/core/src/pool.ts\`, \`tsup.config.ts\`, \`pool-ready-timeout.test.ts\`, \`packages/next/test/middleware.test.ts\`)
- \`wasm/go.mod\` module path
- Pages URL \`jptosso.github.io/coraza-node\` → \`coraza-incubator.github.io/coraza-node\`

## Test plan
- [x] \`pnpm -r test\` — all packages green (94 core, 30 coreruleset, 22 next, 35 fastify, 32 express, 19 nestjs, 12 example-shared)
- [ ] CI green on this PR
- [ ] Merge → next release PR publishes \`preview.1\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)