### PR TITLE
ci: add macOS and Windows runners; fix Windows file-URL handling

### DIFF
--- a/.changeset/wasm-loader-windows-drive-letter.md
+++ b/.changeset/wasm-loader-windows-drive-letter.md
@@ -1,0 +1,22 @@
+---
+'@coraza/core': patch
+---
+
+Fix Windows file-URL handling in the WASM loader and pool worker spawn.
+When a bundler (webpack / Turbopack) duplicates the `URL` class so that
+`fileURLToPath` rejects with `ERR_INVALID_ARG_TYPE`, the previous
+fallback decoded `URL.pathname` directly. On Windows this returns
+`/C:/path/to/file` because that's how the WHATWG URL spec serialises a
+drive-letter file URL — Node's `fs.readFile` and the
+`worker_threads.Worker` constructor both reject that leading slash.
+
+The fallback now strips the leading `/` from drive-letter paths and
+reconstructs the UNC form for `file://server/share/...` URLs, so a
+Windows-bundled middleware that ships its own URL class no longer fails
+to load `coraza.wasm` or spawn the pool worker. The unit test exercises
+the fix against synthetic Windows file URLs on every CI runner, so the
+behaviour is locked in regardless of which platform CI is running on.
+
+Resolves a latent Windows-only bug nobody noticed because CI was
+Linux-only until now; CI now runs on Ubuntu, macOS, and Windows for
+every per-package leg.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,17 +47,25 @@ jobs:
           path: packages/core/src/wasm/coraza.wasm
           retention-days: 7
 
-  # One check row per package × Node version. GitHub renders each matrix
-  # leg as its own status line, so a regression in `@coraza/express` on
-  # Node 24 is visible at a glance without needing to drill in.
+  # One check row per package × Node version × OS. GitHub renders each
+  # matrix leg as its own status line, so a regression in `@coraza/express`
+  # on Node 24 / Windows is visible at a glance without drilling in.
+  #
+  # macOS and Windows runners catch OS-specific bugs in the WASM loader
+  # (file-URL handling, especially Windows drive-letter paths) and
+  # worker_threads spawn. The matrix is fully populated; we don't carry
+  # any conditional skips today. If a leg legitimately needs to skip on
+  # an OS in the future, document the reason here and gate the relevant
+  # step with `if:` rather than dropping the leg from the matrix.
   test:
-    name: Test · ${{ matrix.package }} · Node ${{ matrix.node }}
-    runs-on: ubuntu-latest
+    name: Test · ${{ matrix.package }} · Node ${{ matrix.node }} · ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     needs: build-wasm
-    timeout-minutes: 15
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
         node: ['22', '24']
         package:
           - '@coraza/core'
@@ -103,8 +111,12 @@ jobs:
       - name: Unit tests + coverage
         run: pnpm turbo run test:coverage --filter=${{ matrix.package }}
 
+      # Upload coverage from one canonical leg only — all three OSes run
+      # the same tests against the same code, so coverage numbers are
+      # identical and uploading 3× would just serialize the runs in
+      # Codecov without adding signal.
       - name: Upload coverage
-        if: matrix.node == '22'
+        if: matrix.node == '22' && matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           fail_ci_if_error: false
@@ -158,13 +170,14 @@ jobs:
         run: pnpm -F ${{ matrix.package }} build
 
   e2e:
-    name: E2E · ${{ matrix.adapter }}
-    runs-on: ubuntu-latest
+    name: E2E · ${{ matrix.adapter }} · ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     needs: build-wasm
-    timeout-minutes: 20
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
         adapter: [express, fastify, next, nestjs]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -191,25 +204,63 @@ jobs:
             turbo-e2e-${{ matrix.adapter }}-${{ runner.os }}-
 
       # Playwright browsers are huge (~200 MB) and pinned to the
-      # @playwright/test version. Cache keyed on that version;
-      # on a cache miss the install step re-downloads.
+      # @playwright/test version. Cache keyed on that version + OS so
+      # macOS and Windows don't share Linux's binaries; on a cache miss
+      # the install step re-downloads.
       - name: Resolve Playwright version
         id: pw
+        shell: bash
         run: |
           v=$(pnpm -F @coraza/${{ matrix.adapter }} exec node -p "require('@playwright/test/package.json').version")
           echo "version=$v" >> "$GITHUB_OUTPUT"
-      - name: Cache Playwright browsers
-        id: pw-cache
+      # Playwright caches under a different path on each OS:
+      #   Linux:   ~/.cache/ms-playwright
+      #   macOS:   ~/Library/Caches/ms-playwright
+      #   Windows: %USERPROFILE%\AppData\Local\ms-playwright
+      # The matrix path is selected per-OS to avoid silently caching
+      # nothing.
+      - name: Cache Playwright browsers (Linux)
+        if: runner.os == 'Linux'
+        id: pw-cache-linux
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/ms-playwright
           key: pw-${{ runner.os }}-${{ steps.pw.outputs.version }}
-      - name: Install Playwright browsers
-        if: steps.pw-cache.outputs.cache-hit != 'true'
+      - name: Cache Playwright browsers (macOS)
+        if: runner.os == 'macOS'
+        id: pw-cache-mac
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/Library/Caches/ms-playwright
+          key: pw-${{ runner.os }}-${{ steps.pw.outputs.version }}
+      - name: Cache Playwright browsers (Windows)
+        if: runner.os == 'Windows'
+        id: pw-cache-win
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~\AppData\Local\ms-playwright
+          key: pw-${{ runner.os }}-${{ steps.pw.outputs.version }}
+
+      # Determine cache hit across the three OS-specific cache steps.
+      # GitHub Actions has no straightforward `coalesce` for outputs, so
+      # we resolve the right one with a `||` chain.
+      - name: Install Playwright (Linux/macOS, cache miss)
+        if: runner.os != 'Windows' && (steps.pw-cache-linux.outputs.cache-hit != 'true' && steps.pw-cache-mac.outputs.cache-hit != 'true')
+        shell: bash
         run: pnpm -F @coraza/${{ matrix.adapter }} exec playwright install --with-deps chromium
-      - name: Install Playwright system deps only (cache hit)
-        if: steps.pw-cache.outputs.cache-hit == 'true'
+      - name: Install Playwright system deps only (Linux/macOS, cache hit)
+        if: runner.os != 'Windows' && (steps.pw-cache-linux.outputs.cache-hit == 'true' || steps.pw-cache-mac.outputs.cache-hit == 'true')
+        shell: bash
         run: pnpm -F @coraza/${{ matrix.adapter }} exec playwright install-deps chromium
+      # Windows has no `install-deps` (the chromium build ships with its
+      # own runtime), so we always run a plain `install --with-deps`.
+      # The browser binary is what gets cached; install on cache hit is
+      # a no-op (~1s) but skipping the system-deps step is required
+      # because `install-deps` errors with "not supported" on Windows.
+      - name: Install Playwright (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: pnpm -F @coraza/${{ matrix.adapter }} exec playwright install --with-deps chromium
 
       # Build the example app's full dependency graph. That's the adapter
       # + its own deps (core) AND @coraza/coreruleset, which every example
@@ -221,6 +272,7 @@ jobs:
         run: pnpm turbo run build --filter=@coraza/example-${{ matrix.adapter }}...
       - name: Build both Next examples + deps
         if: matrix.adapter == 'next'
+        shell: bash
         run: |
           pnpm turbo run build --filter=@coraza/example-next15... --filter=@coraza/example-next16...
       - name: E2E
@@ -229,6 +281,6 @@ jobs:
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
-          name: playwright-report-${{ matrix.adapter }}
+          name: playwright-report-${{ matrix.adapter }}-${{ matrix.os }}
           path: packages/${{ matrix.adapter }}/playwright-report
           retention-days: 14

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -59,9 +59,9 @@ jobs:
           retention-days: 7
 
   matrix:
-    name: ${{ matrix.case }} · node-${{ matrix.node }} · ${{ matrix.pool }}
+    name: ${{ matrix.case }} · node-${{ matrix.node }} · ${{ matrix.pool }} · ${{ matrix.os }}
     needs: build-wasm
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -77,6 +77,37 @@ jobs:
           - plain-cjs
         node: ['22', '24']
         pool: ['single', 'pool']
+        os: [ubuntu-latest]
+        # Add a narrow cross-OS slice on the cases most likely to surface
+        # OS-specific bugs (and that don't rely on Linux-specific tooling
+        # at boot). Single Node + single pool mode keeps the additional
+        # cost bounded — we run six extra legs (3 cases × 2 OSes) instead
+        # of 4×-ing the whole matrix.
+        include:
+          - case: express5
+            node: '22'
+            pool: 'single'
+            os: macos-latest
+          - case: express5
+            node: '22'
+            pool: 'single'
+            os: windows-latest
+          - case: fastify5
+            node: '22'
+            pool: 'single'
+            os: macos-latest
+          - case: fastify5
+            node: '22'
+            pool: 'single'
+            os: windows-latest
+          - case: plain-esm
+            node: '22'
+            pool: 'single'
+            os: macos-latest
+          - case: plain-esm
+            node: '22'
+            pool: 'single'
+            os: windows-latest
     env:
       CASE: ${{ matrix.case }}
       POOL: ${{ matrix.pool == 'pool' && '1' || '' }}
@@ -109,8 +140,10 @@ jobs:
         run: pnpm -F @coraza/matrix-${{ matrix.case }} build
 
       - name: Boot case and run driver
+        if: runner.os != 'Windows'
         env:
           CASE_HOST: 127.0.0.1
+        shell: bash
         run: |
           set -uo pipefail
           PORT="${LEG_PORT}"
@@ -140,11 +173,51 @@ jobs:
             exit "$rc"
           fi
 
+      # Windows lacks `pkill` and `kill -TERM "$pid"` semantics differ
+      # under msys; use PowerShell to manage the background server tree.
+      # The driver script is OS-agnostic — it talks HTTP to whatever's on
+      # CASE_PORT — so the only Windows-specific code is the boot/teardown
+      # plumbing.
+      - name: Boot case and run driver (Windows)
+        if: runner.os == 'Windows'
+        env:
+          CASE_HOST: 127.0.0.1
+        shell: pwsh
+        run: |
+          $port = $env:LEG_PORT
+          $log = Join-Path $env:RUNNER_TEMP "$env:CASE-${{ matrix.node }}-${{ matrix.pool }}.log"
+          $env:PORT = $port
+          $env:NODE_ENV = "production"
+          $proc = Start-Process -FilePath "pnpm" -ArgumentList @("-F","@coraza/matrix-$env:CASE","start") -RedirectStandardOutput $log -RedirectStandardError "$log.err" -PassThru -NoNewWindow
+          "APP_PID=$($proc.Id)" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "LOG=$log" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+          $env:CASE_PORT = $port
+          $env:CASE_NAME = $env:CASE
+          $env:BOOT_TIMEOUT = "90"
+          $rc = 0
+          try {
+            & node testing/matrix/scripts/check.mjs
+            $rc = $LASTEXITCODE
+          } catch {
+            $rc = 1
+          }
+
+          # Tear down the server tree. taskkill /T walks child processes.
+          taskkill /PID $proc.Id /T /F 2>$null
+          if ($rc -ne 0) {
+            Write-Host "::group::$env:CASE server log"
+            if (Test-Path $log) { Get-Content $log -Tail 200 }
+            if (Test-Path "$log.err") { Get-Content "$log.err" -Tail 200 }
+            Write-Host "::endgroup::"
+            exit $rc
+          }
+
       - name: Upload server log on failure
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: matrix-log-${{ matrix.case }}-node${{ matrix.node }}-${{ matrix.pool }}
+          name: matrix-log-${{ matrix.case }}-node${{ matrix.node }}-${{ matrix.pool }}-${{ matrix.os }}
           path: ${{ env.LOG }}
           retention-days: 14
 

--- a/packages/core/src/pool.ts
+++ b/packages/core/src/pool.ts
@@ -17,10 +17,9 @@
 //   await tx.close()
 
 import { Worker } from 'node:worker_threads'
-import { fileURLToPath } from 'node:url'
 import { consoleLogger } from './logger.js'
 import { compileWasmModule } from './wasm.js'
-import { defaultWasmPath, defaultPoolWorkerPath } from './wasmResolve.js'
+import { defaultWasmPath, defaultPoolWorkerPath, urlToFsPath } from './wasmResolve.js'
 import type {
   Interruption,
   Logger,
@@ -585,16 +584,11 @@ function spawnSlot(logger: Logger, wasmModule?: WebAssembly.Module): WorkerSlot 
   // defaultWasmPath so Next.js 15's middleware bundler (which rewrites
   // import.meta.url) doesn't explode on pool boot.
   const workerUrl = defaultPoolWorkerPath()
-  // fileURLToPath() throws ERR_INVALID_ARG_TYPE when the URL is an
-  // instance of a bundler-duplicated URL class (webpack under Next 15
-  // middleware). Fall back to manual pathname decode — works across
-  // every bundler because it touches no classes.
-  let workerPath: string
-  try {
-    workerPath = fileURLToPath(workerUrl)
-  } catch {
-    workerPath = decodeURIComponent(workerUrl.pathname)
-  }
+  // Convert URL → fs path. urlToFsPath handles bundler-duplicated URL
+  // classes (webpack under Next 15 middleware) AND Windows drive-letter
+  // URLs whose pathname is `/C:/...` rather than `C:/...` — the
+  // Worker constructor rejects the leading-slash form.
+  const workerPath = urlToFsPath(workerUrl)
   const worker = new Worker(workerPath, {
     // Don't inherit the parent's loader args (e.g. --import tsx) — the worker
     // runs the pre-compiled pool-worker.mjs and doesn't need the TS loader.

--- a/packages/core/src/wasm.ts
+++ b/packages/core/src/wasm.ts
@@ -3,11 +3,11 @@
 
 import { readFile } from 'node:fs/promises'
 import { WASI } from 'node:wasi'
-import { fileURLToPath } from 'node:url'
 import { Abi, type CorazaExports } from './abi.js'
 import { patchInitialMemory, readInitialMemoryPages } from './wasmPatch.js'
 import { createMinimalWasi, useNativeWasi } from './wasi.js'
 import { createHostRegex } from './hostRegex.js'
+import { urlToFsPath } from './wasmResolve.js'
 import type { Logger } from './types.js'
 
 // CRS's regex compilation needs ~100 MiB of linear memory up front. The
@@ -22,8 +22,10 @@ export type WasmSource = ArrayBufferLike | Uint8Array | URL | string
 // node runtime) can embed a second copy of `node:url`, so the URL we
 // constructed in wasmResolve.ts is an instance of a DIFFERENT URL class
 // than the one Node's `fileURLToPath` / `instanceof URL` check against.
-// Duck-type on `protocol`/`pathname` and fall back to manual file-URL
-// decoding when fileURLToPath rejects. See coraza-incubator/coraza-node#16.
+// Duck-type on `protocol`/`pathname` so the loader works whichever URL
+// class the bundle handed us; the actual fs-path conversion (including
+// the Windows drive-letter fix) lives in wasmResolve.ts.
+// See coraza-incubator/coraza-node#16.
 function isUrlLike(x: unknown): x is URL {
   return (
     typeof x === 'object' &&
@@ -31,14 +33,6 @@ function isUrlLike(x: unknown): x is URL {
     typeof (x as { protocol?: unknown }).protocol === 'string' &&
     typeof (x as { pathname?: unknown }).pathname === 'string'
   )
-}
-
-function urlToFsPath(u: URL): string {
-  try {
-    return fileURLToPath(u)
-  } catch {
-    return decodeURIComponent(u.pathname)
-  }
 }
 
 async function resolveBytes(src: WasmSource): Promise<Uint8Array> {

--- a/packages/core/src/wasmResolve.ts
+++ b/packages/core/src/wasmResolve.ts
@@ -18,7 +18,7 @@
 
 import { createRequire } from 'node:module'
 import { dirname, resolve as pathResolve } from 'node:path'
-import { pathToFileURL } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 
 const WASM_REL = 'dist/wasm/coraza.wasm'
 const WORKER_REL = 'dist/pool-worker.mjs'
@@ -114,4 +114,51 @@ export function defaultWasmPathWithMetaUrl(metaUrl: string | undefined): URL {
 
 export function defaultPoolWorkerPathWithMetaUrl(metaUrl: string | undefined): URL {
   return resolveAsset(WORKER_REL, './pool-worker.mjs', metaUrl)
+}
+
+/**
+ * Convert a `file:` URL (or duck-typed equivalent) to a filesystem path.
+ *
+ * Prefers Node's native `fileURLToPath`. Falls back to manual decoding when
+ * the URL is an instance of a bundler-duplicated `URL` class — webpack and
+ * Turbopack embed a second copy of `node:url` when middleware code is
+ * bundled, so the URL fails Node's native `instanceof URL` check inside
+ * `fileURLToPath` with `ERR_INVALID_ARG_TYPE`.
+ *
+ * The manual fallback handles three URL shapes:
+ *
+ *   POSIX:   file:///home/user/coraza.wasm   → /home/user/coraza.wasm
+ *   Windows: file:///C:/Users/me/coraza.wasm → C:/Users/me/coraza.wasm
+ *   Windows UNC: file://server/share/file    → //server/share/file
+ *
+ * The Windows shapes are the ones a hand-written `decodeURIComponent
+ * (u.pathname)` gets wrong — `pathname` is `/C:/...` and Node's `readFile`
+ * / `worker_threads.Worker` constructor then both reject the path. We
+ * detect a leading drive-letter pattern (`/X:/...`) and strip the leading
+ * slash; UNC URLs use `host` instead of leading-component pathname so
+ * we reconstruct `//host/share/...` from `u.host` + `u.pathname`.
+ */
+export function urlToFsPath(u: URL | { protocol: string; pathname: string; host?: string; href?: string }): string {
+  try {
+    return fileURLToPath(u as URL)
+  } catch {
+    /* fall through to manual decode */
+  }
+  const pathname = decodeURIComponent(u.pathname)
+  const host = u.host ?? ''
+  // Windows UNC: file://server/share/path → \\server\share\path. Use the
+  // forward-slash form because both Node fs and the Worker constructor
+  // accept it on Windows, and it sidesteps any backslash-escaping
+  // ambiguity in surrounding code.
+  if (host && host !== '' && host !== 'localhost') {
+    return `//${host}${pathname}`
+  }
+  // Windows drive letter: pathname is `/C:/Users/...` — strip the leading
+  // slash so it becomes `C:/Users/...` which Node's fs accepts. Match
+  // explicitly on `/<letter>:/` to avoid mangling a POSIX path that
+  // legitimately contains a colon later in its first segment.
+  if (/^\/[a-zA-Z]:[\/\\]/.test(pathname)) {
+    return pathname.slice(1)
+  }
+  return pathname
 }

--- a/packages/core/test/wasmResolve.test.ts
+++ b/packages/core/test/wasmResolve.test.ts
@@ -6,6 +6,7 @@ import {
   defaultPoolWorkerPath,
   defaultWasmPathWithMetaUrl,
   defaultPoolWorkerPathWithMetaUrl,
+  urlToFsPath,
 } from '../src/wasmResolve.js'
 
 describe('default WASM / pool-worker resolution', () => {
@@ -76,5 +77,60 @@ describe('default WASM / pool-worker resolution', () => {
     const u = defaultWasmPathWithMetaUrl('https://example.invalid/app.js')
     expect(u.protocol).toBe('file:')
     expect(fileURLToPath(u)).toMatch(/dist[\/\\]wasm[\/\\]coraza\.wasm$/)
+  })
+})
+
+describe('urlToFsPath', () => {
+  // The reason this helper exists at all: under webpack/Turbopack a
+  // bundle can ship a duplicate URL class, so the URL we hand
+  // `fileURLToPath` is no longer `instanceof URL` from Node's POV. The
+  // fallback path below is the one users actually run on Windows.
+  function fakeBundlerUrl(href: string): { protocol: string; pathname: string; host: string; href: string } {
+    const real = new URL(href)
+    return {
+      protocol: real.protocol,
+      pathname: real.pathname,
+      host: real.host,
+      href: real.href,
+    }
+  }
+
+  it('converts a POSIX file URL through fileURLToPath', () => {
+    const u = new URL('file:///home/user/coraza.wasm')
+    expect(urlToFsPath(u)).toBe('/home/user/coraza.wasm')
+  })
+
+  it('falls back when the URL is from a duplicated URL class (POSIX)', () => {
+    // Real URL from Node's classes works on every platform.
+    const u = fakeBundlerUrl('file:///home/user/coraza.wasm')
+    expect(urlToFsPath(u as unknown as URL)).toBe('/home/user/coraza.wasm')
+  })
+
+  it('strips the leading slash from a Windows drive-letter file URL', () => {
+    // Synthetic Windows file URL — `pathname` is `/C:/Users/me/coraza.wasm`
+    // which Node.js readFile rejects on Windows. The helper must return
+    // `C:/Users/me/coraza.wasm` regardless of which platform the unit
+    // test runs on.
+    const u = fakeBundlerUrl('file:///C:/Users/me/coraza.wasm')
+    expect(urlToFsPath(u as unknown as URL)).toBe('C:/Users/me/coraza.wasm')
+  })
+
+  it('strips the leading slash from a Windows drive-letter file URL with a space', () => {
+    const u = fakeBundlerUrl('file:///D:/Program%20Files/coraza/coraza.wasm')
+    expect(urlToFsPath(u as unknown as URL)).toBe('D:/Program Files/coraza/coraza.wasm')
+  })
+
+  it('handles a Windows UNC file URL', () => {
+    // file://server/share/path → //server/share/path
+    const u = fakeBundlerUrl('file://server/share/coraza.wasm')
+    expect(urlToFsPath(u as unknown as URL)).toBe('//server/share/coraza.wasm')
+  })
+
+  it('does not mangle a POSIX path whose first segment contains a colon later', () => {
+    // A POSIX file at /a:b/c is legal. The drive-letter regex requires
+    // exactly `/<letter>:/`, so a multi-character first segment must not
+    // match.
+    const u = fakeBundlerUrl('file:///foo:bar/coraza.wasm')
+    expect(urlToFsPath(u as unknown as URL)).toBe('/foo:bar/coraza.wasm')
   })
 })


### PR DESCRIPTION
## Summary

- Extend `.github/workflows/ci.yml` per-package test matrix to run on `[ubuntu-latest, macos-latest, windows-latest]` × Node 22 / 24 (was Linux-only). Same for the per-adapter Playwright e2e job.
- Add a narrow cross-OS slice to `.github/workflows/matrix.yml` covering Express 5, Fastify 5, and plain-esm on macOS and Windows with Node 22 / single-pool — six extra legs instead of 4×-ing the whole compatibility matrix. Bench and FTW stay Linux-only (Docker + WASM build).
- Fix a latent Windows-only bug in the WASM loader. Helper `urlToFsPath` (now consolidated in `packages/core/src/wasmResolve.ts`) was returning `/C:/path/to/file` from `decodeURIComponent(u.pathname)` for Windows drive-letter file URLs when `fileURLToPath` rejected. Node's `fs.readFile` and the `worker_threads.Worker` constructor both reject that leading slash. The fix strips the leading `/` from drive-letter paths and reconstructs `//host/share/...` for UNC URLs.

## Files changed

CI:
- `.github/workflows/ci.yml` — `test` job now matrices over 3 OSes; `e2e` job matrices over 3 OSes with per-OS Playwright cache paths and a Windows-specific install branch (no `install-deps` on Windows). Codecov upload limited to one canonical leg (Ubuntu / Node 22) to avoid 3× redundant uploads.
- `.github/workflows/matrix.yml` — adds 6 cross-OS extras via `include`; teaches the boot/teardown step a PowerShell variant for Windows (since `pkill` doesn't exist there).

Library:
- `packages/core/src/wasmResolve.ts` — exports new `urlToFsPath(u)` helper with the Windows fix.
- `packages/core/src/wasm.ts` — uses `urlToFsPath` from `wasmResolve.ts` (was an inline copy with the broken fallback).
- `packages/core/src/pool.ts` — same; the inline `try { fileURLToPath } catch { decodeURIComponent }` is replaced with the shared helper.
- `packages/core/test/wasmResolve.test.ts` — 6 new tests exercising synthetic Windows drive-letter and UNC file URLs against the duck-typed (bundler-duplicated) URL shape.
- `.changeset/wasm-loader-windows-drive-letter.md` — patch changeset for `@coraza/core`.

## Library bug + evidence it's fixed

**Bug**: when a bundler (webpack / Turbopack under Next 15 middleware) duplicates the `node:url` class, our URL fails Node's native `instanceof URL` check inside `fileURLToPath` with `ERR_INVALID_ARG_TYPE`. Pre-fix fallback was `decodeURIComponent(u.pathname)` which on Windows produces `/C:/Users/me/coraza.wasm` — Node's `readFile` and `Worker` constructor both reject the leading slash. Result: silent boot failure on Windows under Next.js 15 middleware.

**Fix**: detect the leading `/<letter>:/` pattern and strip the leading slash; reconstruct `//host/share/path` for UNC URLs.

**Evidence (local)**:
- 20 wasmResolve.test.ts tests pass (was 14 + 6 new for Windows shapes)
- All 114 `@coraza/core` tests pass on Linux
- 6 new tests use synthetic Windows file URLs (`new URL('file:///C:/Users/me/coraza.wasm')` projected onto a duck-typed object) so the Windows code path is exercised on every OS

**Evidence (cross-OS)**: this PR's own GHA run will be the first cross-OS exercise of `pool-worker.mjs` spawn under `worker_threads.Worker`. Reviewer should check the test legs go green on all three OSes — that's the load-bearing signal.

## Test plan

- [ ] CI test matrix passes on ubuntu-latest × Node 22 / 24 (regression check)
- [ ] CI test matrix passes on macos-latest × Node 22 / 24 (new)
- [ ] CI test matrix passes on windows-latest × Node 22 / 24 (new — covers Windows file-URL bug fix)
- [ ] E2E Playwright passes on all three OSes for express, fastify, next, nestjs
- [ ] Compatibility matrix cross-OS extras pass on macOS / Windows for Express 5, Fastify 5, plain-esm
- [ ] No regression in coverage thresholds (Codecov upload still gates on Ubuntu / Node 22)

🤖 Generated with [Claude Code](https://claude.com/claude-code)