### PR TITLE
ci(matrix): add npm + yarn legs alongside pnpm

### DIFF
--- a/.github/workflows/matrix-pkg-managers.yml
+++ b/.github/workflows/matrix-pkg-managers.yml
@@ -1,0 +1,201 @@
+name: Compatibility Matrix · Package Managers
+
+# Sibling to matrix.yml. The `Compatibility Matrix` job (matrix.yml) only
+# proves things work under pnpm — the workspace's own package manager.
+# pnpm uses a strict, symlinked node_modules layout; npm and yarn use
+# flat hoisting. A package whose peerDependencies, transitive deps, or
+# `import` resolution implicitly assumes pnpm's layout can fail under
+# npm/yarn (peer-dep duplication, instanceof mismatches across two
+# copies of a dep, missing peer auto-install). The matrix in matrix.yml
+# wouldn't catch any of those.
+#
+# This workflow reproduces what an end user does: `pnpm pack` every
+# publishable @coraza/* package on the workspace side (we keep building
+# with pnpm), then in a fresh consumer project — outside the repo — run
+# the target package manager's `init`, install the tarballs and the
+# framework, drop in a minimal consumer file, boot, and run the
+# 3-scenario probe (testing/matrix/scripts/check.mjs).
+#
+# Yarn means **Yarn 4 (Berry)** — Yarn 1 / Classic is unmaintained.
+# Yarn 4 defaults to PnP; we override with `nodeLinker: node-modules`
+# because PnP changes module resolution semantics and we want to test
+# the same flat-hoisting behaviour npm uses.
+
+on:
+  pull_request:
+    branches: [main, develop]
+  workflow_dispatch:
+  schedule:
+    # Tuesdays 09:00 UTC. Offset from matrix.yml (Mondays 08:00) so a
+    # bad night for a pm registry doesn't take both jobs out at once.
+    - cron: '0 9 * * 2'
+
+concurrency:
+  group: matrix-pkg-managers-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-wasm:
+    name: Build WASM (Docker)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      # Same cache key as ci.yml + matrix.yml so all three workflows share
+      # the WASM artifact. A single Go change rebuilds once across all
+      # three workflows.
+      - name: Cache compiled coraza.wasm
+        id: wasm-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: packages/core/src/wasm/coraza.wasm
+          key: wasm-${{ runner.os }}-${{ hashFiles('wasm/**/*.go', 'wasm/go.mod', 'wasm/go.sum', 'wasm/Dockerfile*', 'wasm/Makefile', 'wasm/version.txt') }}
+          restore-keys: ''
+
+      - name: Build with reproducible Docker image
+        if: steps.wasm-cache.outputs.cache-hit != 'true'
+        run: make -C wasm wasm-docker
+
+      - name: Upload WASM artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coraza-wasm
+          path: packages/core/src/wasm/coraza.wasm
+          retention-days: 7
+
+  pack:
+    name: Pack publishable packages
+    needs: build-wasm
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: coraza-wasm
+          path: packages/core/src/wasm
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build core + adapters
+        run: pnpm turbo run build --filter='./packages/*'
+
+      # `pnpm pack` produces a `.tgz` per publishable package (driven by
+      # `files` in each package.json). It only operates on the current
+      # directory, so we cd into each package dir and write all tarballs
+      # to a single flat output dir — the per-pm legs then do
+      # `pm install <dir>/*.tgz` without iterating.
+      - name: Pack tarballs
+        run: |
+          mkdir -p tarballs
+          dest="$(pwd)/tarballs"
+          for pkg in core coreruleset express fastify nestjs next; do
+            ( cd "packages/${pkg}" && pnpm pack --pack-destination "${dest}" )
+          done
+          echo "--- packed tarballs ---"
+          ls -la tarballs/
+
+      - name: Upload tarballs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coraza-tarballs
+          path: tarballs/
+          retention-days: 7
+
+  consumer:
+    name: ${{ matrix.case }} · ${{ matrix.pm }}
+    needs: pack
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        # Single Node version on purpose: this workflow's axis is the
+        # **package manager**, not the runtime. matrix.yml already
+        # covers Node 22 × 24 across all cases.
+        node: ['22']
+        pm: [npm, yarn, pnpm]
+        case: [express5, fastify5, nestjs11, plain-esm]
+        # next16-proxy is included as a non-blocking signal: see the
+        # `include` block + `continue-on-error` mapping below. The
+        # known regression is tracked on the PR opening this matrix —
+        # Turbopack 16 fails on @coraza/core's tsup-emitted `.d.cts`
+        # type declarations when the package is installed flat (npm /
+        # yarn) or from a tarball (any pm). The pnpm-workspace leg in
+        # matrix.yml passes only because `workspace:*` becomes a
+        # symlink that side-steps Turbopack's package-directory scan.
+        # We surface the failure here intentionally rather than hide it.
+        include:
+          - pm: npm
+            case: next16-proxy
+          - pm: yarn
+            case: next16-proxy
+          - pm: pnpm
+            case: next16-proxy
+    # Per-leg continue-on-error: only the next16-proxy legs are allowed
+    # to fail without blocking the workflow. Every other leg is a hard
+    # gate — npm or yarn breaking express / fastify / nestjs / plain
+    # consumer install would be an immediate publish-blocker.
+    continue-on-error: ${{ matrix.case == 'next16-proxy' }}
+    env:
+      CASE: ${{ matrix.case }}
+      PM: ${{ matrix.pm }}
+      LEG_PORT: '43000'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ matrix.node }}
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: coraza-tarballs
+          path: ${{ runner.temp }}/tarballs
+
+      # corepack ships with Node and gives us a deterministic Yarn 4 and
+      # pnpm without depending on a setup-action's pin. We enable it
+      # unconditionally and let each leg pick its own pm version.
+      - name: Enable corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@9.12.0 --activate
+          corepack prepare yarn@stable --activate
+
+      - name: Print pm versions
+        run: |
+          node --version
+          npm --version
+          corepack yarn --version || true
+          corepack pnpm --version || true
+
+      - name: Run consumer leg
+        env:
+          CASE_HOST: 127.0.0.1
+          TARBALL_DIR: ${{ runner.temp }}/tarballs
+          CONSUMER_ROOT: ${{ runner.temp }}/pm-consumer
+        run: bash testing/matrix/pm-consumers/run-consumer.sh
+
+      - name: Upload server log on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pm-consumer-log-${{ matrix.case }}-${{ matrix.pm }}
+          path: ${{ runner.temp }}/pm-consumer/log
+          retention-days: 14

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -422,5 +422,7 @@ a failure is framework noise or an engine regression.
 | Cross-OS / npm+yarn / tarball CI | `.github/workflows/{matrix,bench,tarball-smoke}.yml` (cross-OS runners, bench gate, npm/yarn legs, tarball smoke) |
 | Example app (Express/Fastify/Next15/Next16/NestJS) | `examples/<name>-app/` — every app implements the shared HTTP contract from `examples/shared/` |
 | CI / release workflow | `.github/workflows/*.yml` |
+| Bundler / framework matrix (workspace install) | `testing/matrix/cases/*` + `.github/workflows/matrix.yml` |
+| Package-manager matrix (tarball install) | `testing/matrix/pm-consumers/*` + `.github/workflows/matrix-pkg-managers.yml` |
 | FTW corpus / overrides | `testing/ftw/*` + `.github/workflows/ftw.yml` |
 | Docs an agent will read | THIS FILE. Not a new doc. |

--- a/testing/matrix/pm-consumers/README.md
+++ b/testing/matrix/pm-consumers/README.md
@@ -1,0 +1,52 @@
+# pm-consumers — package-manager × adapter consumer templates
+
+These directories are **not** workspace packages. They are templates the
+`matrix-pkg-managers.yml` workflow copies into a freshly-`<pm> init -y`'d
+consumer project to verify that the **published** `@coraza/*` tarballs
+resolve and run cleanly under npm, yarn (4 / Berry), and pnpm.
+
+The matrix in `testing/matrix/cases/` only proves things work under pnpm
+(the workspace's own package manager). pnpm's strict, symlinked
+`node_modules` differs materially from npm's and yarn's flat hoisting.
+Peer-dep duplication, `instanceof` mismatches across two copies of a
+transitive dep, missing peer-dep auto-install — none of those would
+surface in the existing matrix.
+
+## How a leg runs
+
+1. `pnpm pack` every publishable package (`core`, `coreruleset`, `express`,
+   `fastify`, `nestjs`, `next`) into `/tmp/coraza-tarballs/`.
+2. The workflow `mkdir`s a fresh consumer dir outside the repo.
+3. `<pm> init -y` is run. For yarn we additionally
+   `corepack enable && yarn set version stable` (Yarn 4).
+4. The full set of tarballs is installed:
+   - `npm install <tarball>...`
+   - `yarn add <tarball>...` (Yarn 4)
+   - `pnpm add <tarball>...`
+   plus the framework dependency (`express@5`, `fastify@5`, `next@16`,
+   `@nestjs/common`+`@nestjs/core`+`@nestjs/platform-express`+`reflect-metadata`+`rxjs`).
+5. The matching template directory is copied in.
+6. The server is booted with `tsx server.ts` (or `node server.mjs` for
+   `plain-esm`) on `$PORT`.
+7. `testing/matrix/scripts/check.mjs` fires the three-scenario probe:
+   `/healthz` → 200, `/search?q=<SQLi>` → 403, `POST /echo {msg:<XSS>}`
+   → 403.
+
+## Constraints on these templates
+
+- **No `workspace:*` references.** They install from real tarballs, the
+  same way an end user would.
+- **No relative paths into the repo.** `wasmSource` is omitted so the
+  loader resolves the asset via `@coraza/core/dist/wasm/coraza.wasm`,
+  which is the path bundlers and end users hit.
+- **One source file per case.** Anything more complex (Next's app
+  router, Nest module wiring) lives in subdirs but the entry point
+  remains a single root file.
+- **Mirror the `testing/matrix/cases/<case>/` shape.** The check.mjs
+  contract is the same — drift between the two would be a regression
+  trap.
+
+If you find a package-manager-specific bug while iterating locally, do
+not paper over it in these templates. The point is to *surface* the
+bug. Add a workflow-level comment explaining the failure and report
+upstream.

--- a/testing/matrix/pm-consumers/express5/server.mjs
+++ b/testing/matrix/pm-consumers/express5/server.mjs
@@ -1,0 +1,42 @@
+// pm-consumer / express5 — bare consumer, installed from tarballs by the
+// target package manager (npm / yarn / pnpm). No workspace shortcut, no
+// relative wasmSource — the loader must resolve coraza.wasm via the
+// installed @coraza/core package.
+import express from 'express'
+import http from 'node:http'
+import { createWAF, createWAFPool } from '@coraza/core'
+import { recommended } from '@coraza/coreruleset'
+import { coraza } from '@coraza/express'
+
+const port = Number(process.env.PORT ?? 3000)
+const usePool = process.env.POOL === '1'
+const poolSize = Number(process.env.POOL_SIZE ?? 2)
+const mode = process.env.MODE ?? 'block'
+const rules = recommended()
+const waf = usePool
+  ? await createWAFPool({ rules, mode, size: poolSize })
+  : await createWAF({ rules, mode })
+
+const app = express()
+app.use(express.json({ limit: '1mb' }))
+app.use(coraza({ waf }))
+
+app.get('/healthz', (_req, res) => {
+  res.status(200).type('text/plain').send('ok')
+})
+app.get('/', (_req, res) => {
+  res.status(200).json({ ok: true })
+})
+app.get('/search', (req, res) => {
+  const q = typeof req.query.q === 'string' ? req.query.q : ''
+  res.status(200).json({ q, len: q.length })
+})
+app.post('/echo', (req, res) => {
+  res.status(200).json(req.body ?? {})
+})
+
+const server = http.createServer(app)
+server.listen(port, '0.0.0.0', () => {
+  process.stdout.write(`pm-consumer-express5 listening on :${port}\n`)
+})
+process.on('SIGTERM', () => server.close(() => process.exit(0)))

--- a/testing/matrix/pm-consumers/fastify5/server.mjs
+++ b/testing/matrix/pm-consumers/fastify5/server.mjs
@@ -1,0 +1,36 @@
+// pm-consumer / fastify5 — bare consumer, installed from tarballs by the
+// target package manager (npm / yarn / pnpm).
+import Fastify from 'fastify'
+import { createWAF, createWAFPool } from '@coraza/core'
+import { recommended } from '@coraza/coreruleset'
+import { coraza } from '@coraza/fastify'
+
+const port = Number(process.env.PORT ?? 3000)
+const usePool = process.env.POOL === '1'
+const poolSize = Number(process.env.POOL_SIZE ?? 2)
+const mode = process.env.MODE ?? 'block'
+const rules = recommended()
+const waf = usePool
+  ? await createWAFPool({ rules, mode, size: poolSize })
+  : await createWAF({ rules, mode })
+
+const app = Fastify({ logger: false, bodyLimit: 1024 * 1024 })
+await app.register(coraza, { waf })
+
+app.get('/healthz', async (_req, reply) => {
+  reply.type('text/plain')
+  return 'ok'
+})
+app.get('/', async () => ({ ok: true }))
+app.get('/search', async (req) => {
+  const q = req.query?.q ?? ''
+  return { q, len: q.length }
+})
+app.post('/echo', async (req) => req.body ?? {})
+
+await app.listen({ port, host: '0.0.0.0' })
+process.stdout.write(`pm-consumer-fastify5 listening on :${port}\n`)
+process.on('SIGTERM', async () => {
+  await app.close()
+  process.exit(0)
+})

--- a/testing/matrix/pm-consumers/nestjs11/server.ts
+++ b/testing/matrix/pm-consumers/nestjs11/server.ts
@@ -1,0 +1,68 @@
+// pm-consumer / nestjs11 — bare consumer, installed from tarballs by the
+// target package manager. Uses TypeScript decorators (NestJS contract);
+// tsx transpiles at runtime.
+import 'reflect-metadata'
+import { NestFactory } from '@nestjs/core'
+import {
+  Body,
+  Controller,
+  Get,
+  Header,
+  Module,
+  Post,
+  Query,
+} from '@nestjs/common'
+import { createWAF, createWAFPool } from '@coraza/core'
+import { recommended } from '@coraza/coreruleset'
+import { CorazaModule } from '@coraza/nestjs'
+
+const port = Number(process.env.PORT ?? 3000)
+const usePool = process.env.POOL === '1'
+const poolSize = Number(process.env.POOL_SIZE ?? 2)
+const mode = (process.env.MODE ?? 'block') as 'detect' | 'block'
+const rules = recommended()
+const waf = usePool
+  ? await createWAFPool({ rules, mode, size: poolSize })
+  : await createWAF({ rules, mode })
+
+@Controller()
+class AppController {
+  @Get('/')
+  root(): unknown {
+    return { ok: true }
+  }
+
+  @Get('/healthz')
+  @Header('content-type', 'text/plain')
+  healthz(): string {
+    return 'ok'
+  }
+
+  @Get('/search')
+  search(@Query('q') q?: string): unknown {
+    const value = q ?? ''
+    return { q: value, len: value.length }
+  }
+
+  @Post('/echo')
+  echo(@Body() body: unknown): unknown {
+    return body ?? {}
+  }
+}
+
+@Module({
+  imports: [CorazaModule.forRoot({ waf })],
+  controllers: [AppController],
+})
+class AppModule {}
+
+const app = await NestFactory.create(AppModule, {
+  logger: ['error', 'warn'],
+  rawBody: true,
+})
+await app.listen(port)
+process.stdout.write(`pm-consumer-nestjs11 listening on :${port}\n`)
+process.on('SIGTERM', async () => {
+  await app.close()
+  process.exit(0)
+})

--- a/testing/matrix/pm-consumers/nestjs11/tsconfig.json
+++ b/testing/matrix/pm-consumers/nestjs11/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": false
+  },
+  "include": ["server.ts"]
+}

--- a/testing/matrix/pm-consumers/next16-proxy/next.config.js
+++ b/testing/matrix/pm-consumers/next16-proxy/next.config.js
@@ -1,0 +1,5 @@
+/** @type {import('next').NextConfig} */
+export default {
+  reactStrictMode: true,
+  serverExternalPackages: ['@coraza/core'],
+}

--- a/testing/matrix/pm-consumers/next16-proxy/src/app/echo/route.ts
+++ b/testing/matrix/pm-consumers/next16-proxy/src/app/echo/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from 'next/server'
+
+export async function POST(req: Request): Promise<Response> {
+  const body = await req.json().catch(() => ({}))
+  return NextResponse.json(body ?? {})
+}

--- a/testing/matrix/pm-consumers/next16-proxy/src/app/healthz/route.ts
+++ b/testing/matrix/pm-consumers/next16-proxy/src/app/healthz/route.ts
@@ -1,0 +1,3 @@
+export async function GET(): Promise<Response> {
+  return new Response('ok', { headers: { 'content-type': 'text/plain' } })
+}

--- a/testing/matrix/pm-consumers/next16-proxy/src/app/layout.tsx
+++ b/testing/matrix/pm-consumers/next16-proxy/src/app/layout.tsx
@@ -1,0 +1,9 @@
+export const metadata = { title: 'pm-consumer-next16-proxy' }
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/testing/matrix/pm-consumers/next16-proxy/src/app/page.tsx
+++ b/testing/matrix/pm-consumers/next16-proxy/src/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <pre>{JSON.stringify({ ok: true })}</pre>
+}

--- a/testing/matrix/pm-consumers/next16-proxy/src/app/search/route.ts
+++ b/testing/matrix/pm-consumers/next16-proxy/src/app/search/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse, type NextRequest } from 'next/server'
+
+export async function GET(req: NextRequest): Promise<Response> {
+  const q = req.nextUrl.searchParams.get('q') ?? ''
+  return NextResponse.json({ q, len: q.length })
+}

--- a/testing/matrix/pm-consumers/next16-proxy/src/proxy.ts
+++ b/testing/matrix/pm-consumers/next16-proxy/src/proxy.ts
@@ -1,0 +1,18 @@
+// pm-consumer / next16-proxy — Next 16 proxy.ts hosted in src/. Boots
+// against the published @coraza/* tarballs installed by the target
+// package manager. wasmSource is intentionally omitted: the loader must
+// resolve coraza.wasm by walking node_modules from @coraza/core, which
+// is the path real users hit.
+import { createWAF, createWAFPool } from '@coraza/core'
+import { recommended } from '@coraza/coreruleset'
+import { coraza } from '@coraza/next'
+
+const usePool = process.env.POOL === '1'
+const poolSize = Number(process.env.POOL_SIZE ?? 2)
+
+const wafPromise = usePool
+  ? createWAFPool({ rules: recommended(), mode: 'block', size: poolSize })
+  : createWAF({ rules: recommended(), mode: 'block' })
+
+export const proxy = coraza({ waf: wafPromise })
+export const config = { matcher: '/:path*' }

--- a/testing/matrix/pm-consumers/next16-proxy/tsconfig.json
+++ b/testing/matrix/pm-consumers/next16-proxy/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "module": "esnext",
+    "moduleResolution": "Bundler",
+    "jsx": "preserve",
+    "noEmit": true,
+    "incremental": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "allowJs": true,
+    "plugins": [{ "name": "next" }]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules", ".next"]
+}

--- a/testing/matrix/pm-consumers/plain-esm/server.mjs
+++ b/testing/matrix/pm-consumers/plain-esm/server.mjs
@@ -1,0 +1,84 @@
+// pm-consumer / plain-esm — `import { createWAF } from '@coraza/core'`
+// with zero framework, zero bundler. Validates the ESM resolve path of
+// the published @coraza/core tarball end-to-end under each pm.
+import http from 'node:http'
+import { createWAF, createWAFPool } from '@coraza/core'
+import { recommended } from '@coraza/coreruleset'
+
+const port = Number(process.env.PORT ?? 3000)
+const usePool = process.env.POOL === '1'
+const poolSize = Number(process.env.POOL_SIZE ?? 2)
+const mode = process.env.MODE ?? 'block'
+const rules = recommended()
+const waf = usePool
+  ? await createWAFPool({ rules, mode, size: poolSize })
+  : await createWAF({ rules, mode })
+
+function sendJson(res, status, body, contentType) {
+  const payload = typeof body === 'string' ? body : JSON.stringify(body)
+  res.writeHead(status, { 'content-type': contentType || 'application/json' })
+  res.end(payload)
+}
+
+async function readBody(req) {
+  const chunks = []
+  for await (const c of req) chunks.push(c)
+  return Buffer.concat(chunks)
+}
+
+const server = http.createServer(async (req, res) => {
+  const url = new URL(req.url || '/', `http://${req.headers.host || 'localhost'}`)
+  if (req.method === 'GET' && url.pathname === '/healthz') {
+    return sendJson(res, 200, 'ok', 'text/plain')
+  }
+
+  const body =
+    req.method === 'GET' || req.method === 'HEAD' ? Buffer.alloc(0) : await readBody(req)
+
+  const tx = await waf.newTransaction()
+  try {
+    const headers = []
+    for (const [k, v] of Object.entries(req.headers)) {
+      if (v == null) continue
+      if (Array.isArray(v)) for (const vv of v) headers.push([k, vv])
+      else headers.push([k, String(v)])
+    }
+    const interrupted = await tx.processRequestBundle(
+      {
+        method: req.method || 'GET',
+        url: url.pathname + url.search,
+        protocol: 'HTTP/1.1',
+        headers,
+        remoteAddr: req.socket.remoteAddress || '',
+      },
+      body.length > 0 ? new Uint8Array(body) : undefined,
+    )
+    if (interrupted) {
+      const interruption = await tx.interruption()
+      const status = interruption?.status || 403
+      return sendJson(res, status, `blocked by rule ${interruption?.ruleId ?? 0}`, 'text/plain')
+    }
+
+    if (req.method === 'GET' && url.pathname === '/') {
+      return sendJson(res, 200, { ok: true })
+    }
+    if (req.method === 'GET' && url.pathname === '/search') {
+      const q = url.searchParams.get('q') ?? ''
+      return sendJson(res, 200, { q, len: q.length })
+    }
+    if (req.method === 'POST' && url.pathname === '/echo') {
+      let parsed
+      try { parsed = JSON.parse(body.toString('utf8') || '{}') } catch { parsed = {} }
+      return sendJson(res, 200, parsed)
+    }
+    sendJson(res, 404, { error: 'not found' })
+  } finally {
+    await tx.processLogging()
+    await tx.close()
+  }
+})
+
+server.listen(port, '0.0.0.0', () => {
+  process.stdout.write(`pm-consumer-plain-esm listening on :${port}\n`)
+})
+process.on('SIGTERM', () => server.close(() => process.exit(0)))

--- a/testing/matrix/pm-consumers/run-consumer.sh
+++ b/testing/matrix/pm-consumers/run-consumer.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+# testing/matrix/pm-consumers/run-consumer.sh — boot one
+# (case × package-manager) leg against a fresh consumer project that
+# installs the published @coraza/* tarballs.
+#
+# Inputs (env):
+#   CASE        one of: express5 | fastify5 | nestjs11 | next16-proxy | plain-esm
+#   PM          one of: npm | yarn | pnpm
+#   LEG_PORT    base port (default 43000); a per-leg port is derived
+#   RUNNER_TEMP path to a writable scratch dir (CI sets this; local
+#               default is `/tmp` if unset)
+#   TARBALL_DIR path to the dir holding the @coraza/*.tgz tarballs.
+#               In CI: ${RUNNER_TEMP}/tarballs (the download-artifact
+#               step). Locally: caller exports it.
+#   CONSUMER_ROOT scratch dir for the consumer project itself (default
+#                ${RUNNER_TEMP:-/tmp}/pm-consumer)
+#   BOOT_TIMEOUT seconds for /healthz to come up (default 90; Next +
+#               npm cold install is the slowest combo)
+#
+# The script intentionally avoids `set -e`: it captures the driver's
+# exit code separately so it can dump server logs on failure before
+# bailing.
+
+set -uo pipefail
+
+CASE="${CASE:?CASE env var required}"
+PM="${PM:?PM env var required}"
+LEG_PORT="${LEG_PORT:-43000}"
+BOOT_TIMEOUT="${BOOT_TIMEOUT:-90}"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+TEMPLATES_DIR="${REPO_ROOT}/testing/matrix/pm-consumers"
+CHECK_SCRIPT="${REPO_ROOT}/testing/matrix/scripts/check.mjs"
+
+SCRATCH="${RUNNER_TEMP:-/tmp}"
+TARBALL_DIR="${TARBALL_DIR:-${SCRATCH}/tarballs}"
+CONSUMER_ROOT="${CONSUMER_ROOT:-${SCRATCH}/pm-consumer}"
+
+if [[ ! -d "${TARBALL_DIR}" ]]; then
+  echo "[pm] tarball dir not found at ${TARBALL_DIR}" >&2
+  echo "[pm] hint: run 'pnpm -F \"./packages/*\" build && pnpm pack ...' first" >&2
+  exit 2
+fi
+
+if ! ls "${TARBALL_DIR}"/*.tgz >/dev/null 2>&1; then
+  echo "[pm] no .tgz files under ${TARBALL_DIR}" >&2
+  exit 2
+fi
+
+template_dir="${TEMPLATES_DIR}/${CASE}"
+if [[ ! -d "${template_dir}" ]]; then
+  echo "[pm] unknown case: ${CASE}" >&2
+  exit 2
+fi
+
+# Derive a stable per-leg port. Hash CASE+PM into the offset so two
+# legs running in the same runner don't collide if a previous one
+# leaked.
+hash="$( ( echo -n "${CASE}-${PM}" | sha1sum 2>/dev/null || echo -n "${CASE}-${PM}" | shasum -a 1 ) | head -c 4 )"
+port=$(( LEG_PORT + 0x${hash} % 1000 ))
+
+consumer_dir="${CONSUMER_ROOT}/${CASE}-${PM}"
+# Log dir is derived from CONSUMER_ROOT (not SCRATCH) so a caller
+# overriding CONSUMER_ROOT for an isolated local run gets all artefacts
+# (per-leg consumer dirs + their logs) under a single root.
+log_dir="${CONSUMER_ROOT}/log"
+mkdir -p "${log_dir}"
+log_file="${log_dir}/${CASE}-${PM}.log"
+install_log="${log_dir}/${CASE}-${PM}.install.log"
+
+rm -rf "${consumer_dir}"
+mkdir -p "${consumer_dir}"
+
+echo "[pm] case=${CASE} pm=${PM} port=${port}"
+echo "[pm] consumer dir: ${consumer_dir}"
+echo "[pm] tarballs: $(ls -1 "${TARBALL_DIR}"/*.tgz | wc -l) file(s) under ${TARBALL_DIR}"
+
+cd "${consumer_dir}"
+
+# ---- 1. init project ----------------------------------------------------
+case "${PM}" in
+  npm)
+    npm init -y >/dev/null
+    # type:module so server.mjs ESM imports resolve as expected.
+    node -e 'const f=require("fs");const p="package.json";const j=JSON.parse(f.readFileSync(p,"utf8"));j.type="module";f.writeFileSync(p,JSON.stringify(j,null,2)+"\n")'
+    ;;
+  yarn)
+    # corepack-resolved Yarn 4 (Berry). Must be invoked via corepack to
+    # avoid PATH order surprises on hosted runners.
+    corepack yarn init -y >/dev/null
+    # PnP would change module resolution out from under us; we want flat
+    # node_modules to actually exercise hoisting against npm.
+    cat >.yarnrc.yml <<'EOF'
+nodeLinker: node-modules
+enableImmutableInstalls: false
+EOF
+    node -e 'const f=require("fs");const p="package.json";const j=JSON.parse(f.readFileSync(p,"utf8"));j.type="module";f.writeFileSync(p,JSON.stringify(j,null,2)+"\n")'
+    ;;
+  pnpm)
+    corepack pnpm init >/dev/null
+    node -e 'const f=require("fs");const p="package.json";const j=JSON.parse(f.readFileSync(p,"utf8"));j.type="module";f.writeFileSync(p,JSON.stringify(j,null,2)+"\n")'
+    cat >.npmrc <<'EOF'
+auto-install-peers=true
+strict-peer-dependencies=false
+EOF
+    ;;
+  *)
+    echo "[pm] unknown PM: ${PM}" >&2
+    exit 2
+    ;;
+esac
+
+# ---- 2. assemble dependency list ----------------------------------------
+# `framework_deps` are the peer/runtime packages a real consumer would
+# install alongside @coraza/<adapter>. We pin to the same major the
+# matrix.yml cases use so a Next 17 bump doesn't silently flip behaviour
+# under us; bumps belong in a deliberate PR.
+case "${CASE}" in
+  express5)
+    framework_deps=(express@5.0.1)
+    runner_deps=()
+    runtime_cmd=(node server.mjs)
+    ;;
+  fastify5)
+    framework_deps=(fastify@5)
+    runner_deps=()
+    runtime_cmd=(node server.mjs)
+    ;;
+  nestjs11)
+    framework_deps=(
+      "@nestjs/common@^11.0.0"
+      "@nestjs/core@^11.0.0"
+      "@nestjs/platform-express@^11.0.0"
+      "reflect-metadata@^0.2.2"
+      "rxjs@^7.8.1"
+    )
+    # tsx so the decorator-bearing TS source runs without a separate
+    # tsc step. tsconfig.json lives next to server.ts in the template.
+    runner_deps=("tsx@^4.19.1" "typescript@^5.6.2")
+    runtime_cmd=(npx --yes tsx server.ts)
+    ;;
+  next16-proxy)
+    framework_deps=(
+      "next@^16.0.0"
+      "react@^18.3.1"
+      "react-dom@^18.3.1"
+    )
+    runner_deps=("typescript@^5.6.2" "@types/react@^18.3.3" "@types/node@^22.7.5")
+    runtime_cmd=(npx --yes next start -p "${port}")
+    ;;
+  plain-esm)
+    framework_deps=()
+    runner_deps=()
+    runtime_cmd=(node server.mjs)
+    ;;
+esac
+
+# Tarball list — install ALL of them, even on a leg that only imports
+# one adapter. The point is to validate every published @coraza/* under
+# the target pm.
+mapfile -t tarballs < <(ls "${TARBALL_DIR}"/*.tgz)
+
+# ---- 3. install ---------------------------------------------------------
+echo "[pm] installing tarballs + framework deps via ${PM}"
+case "${PM}" in
+  npm)
+    npm install --no-audit --no-fund --foreground-scripts \
+      "${tarballs[@]}" "${framework_deps[@]}" "${runner_deps[@]}" \
+      >"${install_log}" 2>&1
+    rc_install=$?
+    ;;
+  yarn)
+    # Yarn 4 doesn't accept '@version' suffixes the same way for local
+    # tarballs vs registry entries — splitting the calls is safer.
+    corepack yarn add "${tarballs[@]}" >"${install_log}" 2>&1
+    rc_install=$?
+    if [[ "${rc_install}" -eq 0 && ${#framework_deps[@]} -gt 0 ]]; then
+      corepack yarn add "${framework_deps[@]}" >>"${install_log}" 2>&1
+      rc_install=$?
+    fi
+    if [[ "${rc_install}" -eq 0 && ${#runner_deps[@]} -gt 0 ]]; then
+      corepack yarn add --dev "${runner_deps[@]}" >>"${install_log}" 2>&1
+      rc_install=$?
+    fi
+    ;;
+  pnpm)
+    corepack pnpm add "${tarballs[@]}" "${framework_deps[@]}" "${runner_deps[@]}" \
+      >"${install_log}" 2>&1
+    rc_install=$?
+    ;;
+esac
+
+if [[ "${rc_install}" -ne 0 ]]; then
+  echo "[pm] install FAILED (rc=${rc_install}). Tail of install log:" >&2
+  tail -n 100 "${install_log}" >&2 || true
+  exit "${rc_install}"
+fi
+
+# ---- 4. drop the consumer template into the project ---------------------
+# Use a tar pipeline so we don't depend on rsync being on the runner.
+( cd "${template_dir}" && tar cf - . ) | tar xf -
+
+# ---- 5. case-specific build step (Next only) ----------------------------
+if [[ "${CASE}" == "next16-proxy" ]]; then
+  echo "[pm] running 'next build'"
+  build_log="${log_dir}/${CASE}-${PM}.build.log"
+  npx --yes next build >"${build_log}" 2>&1
+  rc_build=$?
+  if [[ "${rc_build}" -ne 0 ]]; then
+    echo "[pm] next build FAILED (rc=${rc_build}). Tail of build log:" >&2
+    tail -n 200 "${build_log}" >&2 || true
+    exit "${rc_build}"
+  fi
+fi
+
+# ---- 6. boot the server -------------------------------------------------
+echo "[pm] booting: ${runtime_cmd[*]}"
+PORT="${port}" NODE_ENV=production "${runtime_cmd[@]}" >"${log_file}" 2>&1 &
+app_pid=$!
+
+# ---- 7. probe via the shared driver -------------------------------------
+CASE_PORT="${port}" \
+  CASE_HOST="${CASE_HOST:-127.0.0.1}" \
+  CASE_NAME="${CASE}-${PM}" \
+  BOOT_TIMEOUT="${BOOT_TIMEOUT}" \
+  node "${CHECK_SCRIPT}"
+rc=$?
+
+# ---- 8. teardown --------------------------------------------------------
+kill -TERM "${app_pid}" 2>/dev/null || true
+# Reach descendants too — Next forks worker processes that don't sit in
+# the immediate child tree.
+pkill -TERM -P "${app_pid}" 2>/dev/null || true
+sleep 0.5
+kill -KILL "${app_pid}" 2>/dev/null || true
+pkill -KILL -P "${app_pid}" 2>/dev/null || true
+wait "${app_pid}" 2>/dev/null || true
+
+# Belt-and-braces: anything still holding our port escapes the kill tree.
+if command -v lsof >/dev/null 2>&1; then
+  lsof -ti:"${port}" 2>/dev/null | xargs -r kill -KILL 2>/dev/null || true
+elif command -v fuser >/dev/null 2>&1; then
+  fuser -k -KILL "${port}/tcp" 2>/dev/null || true
+fi
+
+if [[ "${rc}" -ne 0 ]]; then
+  echo "::group::${CASE}/${PM} server log"
+  tail -n 200 "${log_file}" || true
+  echo "::endgroup::"
+fi
+
+exit "${rc}"


### PR DESCRIPTION
## Summary

The existing Compatibility Matrix (`.github/workflows/matrix.yml`) only proves things work under **pnpm** — the workspace's own package manager. pnpm uses a strict, symlinked `node_modules` layout; npm and yarn flatten by default. A package whose `peerDependencies`, transitive deps, or `import` resolution implicitly assumes pnpm's layout can fail under npm/yarn (peer-dep duplication, `instanceof` mismatches across two copies of a dep, missing peer auto-install). The matrix in `matrix.yml` wouldn't catch any of those.

## What this workflow runs

`.github/workflows/matrix-pkg-managers.yml`:

1. Builds WASM (cached, shared with `ci.yml` + `matrix.yml` cache key).
2. `pnpm pack`s every publishable `@coraza/*` package into a flat artifact dir.
3. For each `(case × pm)` leg, on Node 22 (single Node version on purpose — this workflow's axis is the package manager, not the runtime; `matrix.yml` already covers Node 22 × 24):
   - Creates a fresh consumer project **outside** the repo.
   - Runs `<pm> init -y` (with corepack-pinned versions; Yarn means **Yarn 4 / Berry**, not Yarn 1 Classic).
   - Installs the local tarballs + the framework dep via the target pm.
   - Drops in a minimal consumer template (mirrors the `testing/matrix/cases/<case>/` shape but uses no `workspace:*` and no relative WASM path — the loader must resolve `coraza.wasm` via the installed `@coraza/core` package).
   - Boots the server and runs the same 3-scenario probe as `matrix.yml` (`testing/matrix/scripts/check.mjs`).

Cases: `express5`, `fastify5`, `nestjs11`, `plain-esm`, `next16-proxy`.
Package managers: `npm`, `yarn` (Yarn 4 with `nodeLinker: node-modules` so PnP doesn't change resolution semantics out from under us), `pnpm`.

Triggers: PR to `main`/`develop`, `workflow_dispatch`, and a weekly cron (Tuesdays 09:00 UTC, offset from `matrix.yml`'s Mondays 08:00).

## Local pass table (Node 25, hard-gate combos)

| case | npm | yarn | pnpm |
|---|---|---|---|
| `express5` | PASS | PASS | PASS |
| `fastify5` | PASS | PASS | PASS |
| `nestjs11` | PASS | PASS | PASS |
| `plain-esm` | PASS | PASS | PASS |

(`200 / 403 / 403` on `/healthz` / `/search?q=<SQLi>` / `POST /echo {msg:<XSS>}` for every hard-gate combo.)

## Bug surfaced — Turbopack 16 + `@coraza/core` `.d.cts` declarations

`next16-proxy` fails on **all three pms** when `@coraza/core` is installed from a tarball into a flat or pnpm-style real `node_modules/`:

```
./node_modules/@coraza/core/dist/index.d.cts
Specified module format (CommonJs) is not matching the module format of the source code (EcmaScript Modules)
The CommonJs module format was specified in the package.json that is affecting this source file or by using an special extension, but Ecmascript import/export syntax is used in the source code.
```

Turbopack 16 scans the installed package directory and rejects the tsup-emitted `.d.cts` declaration files because they declare CommonJS (by extension) but contain ESM `import`/`export` syntax. The `matrix.yml` pnpm-workspace leg passes **only** because `workspace:*` becomes a symlink that side-steps that directory scan — once the package ships to npm and a real consumer installs the tarball, every pm hits this.

**Reproduction (any pm):**
```sh
pnpm pack ./packages/core --pack-destination /tmp/tarballs
mkdir /tmp/consumer && cd /tmp/consumer
npm init -y
npm install /tmp/tarballs/coraza-core-*.tgz next@16 react@18 react-dom@18
# ... drop in a minimal next16 app with a proxy.ts importing @coraza/core
npx next build
# → Turbopack build failed with 3 errors: ./node_modules/@coraza/core/dist/index.d.cts ...
```

Per the contributor guide ("If you find a package-manager-specific bug, STOP and report it — don't paper over it"), the next16-proxy legs are kept in the matrix as a **non-blocking signal** (`continue-on-error: true`) so the failure stays visible until the underlying tsup output is fixed. Suspected fix: have `tsup` emit `.d.ts`-only (no `.d.cts` duplicate) since both files have identical content for our type surface, or rewrite the `.d.cts` to use CJS-style `export =` syntax. Tracking as a follow-up; this PR shouldn't paper over it.

## Test plan

- [ ] CI runs `consumer (case × pm)` legs on this PR.
- [ ] Hard-gate legs (every `case` other than `next16-proxy`) all pass.
- [ ] `next16-proxy` legs report failures but don't fail the workflow (`continue-on-error: true` honoured).
- [ ] Server logs uploaded as artifacts on each failed leg.
- [ ] Weekly cron triggers a fresh run on its schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)