### PR TITLE
fix(build): stop shipping .d.cts (Turbopack 16 rejects ESM-syntax .cts)

### DIFF
--- a/.changeset/dts-cts-turbopack-compat.md
+++ b/.changeset/dts-cts-turbopack-compat.md
@@ -1,0 +1,23 @@
+---
+'@coraza/core': patch
+'@coraza/coreruleset': patch
+'@coraza/express': patch
+'@coraza/fastify': patch
+'@coraza/nestjs': patch
+'@coraza/next': patch
+---
+
+Stop shipping `.d.cts` declaration files. tsup emits them with ESM
+`import` syntax inside a `.cts` extension; Turbopack 16's package
+scanner rejects this with "Specified module format (CommonJs) is not
+matching the module format of the source code (EcmaScript Modules)"
+and refuses to build any consumer that has the package in
+`node_modules`.
+
+`exports.types` in every package already points only at `.d.ts`,
+which TypeScript resolves under both `nodenext` and `bundler`
+moduleResolution for type-only imports — so the `.d.cts` files were
+dead weight that only triggered false-positives.
+
+Surfaced by the new bundler/runtime compatibility matrix exercising
+Next 16 + Turbopack against tarballs installed via npm/yarn/pnpm.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@coraza/core",
   "version": "0.1.0-preview.1",
-  "description": "Experimental community packaging of OWASP Coraza WAF for Node.js — core engine (WASM loader). Not an official Coraza/OWASP release.",
+  "description": "Experimental community packaging of OWASP Coraza WAF for Node.js \u2014 core engine (WASM loader). Not an official Coraza/OWASP release.",
   "license": "Apache-2.0",
   "author": "Juan Pablo Tosso <jptosso@gmail.com>",
   "homepage": "https://github.com/coraza-incubator/coraza-node",
@@ -44,7 +44,7 @@
     "node": ">=22"
   },
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && find dist -name \"*.d.cts\" -delete && find dist -name \"*.d.cts.map\" -delete",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "typecheck": "tsc --noEmit",

--- a/packages/coreruleset/package.json
+++ b/packages/coreruleset/package.json
@@ -37,7 +37,7 @@
     "node": ">=22"
   },
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && find dist -name \"*.d.cts\" -delete && find dist -name \"*.d.cts.map\" -delete",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "typecheck": "tsc --noEmit",

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -36,7 +36,7 @@
     "node": ">=22"
   },
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && find dist -name \"*.d.cts\" -delete && find dist -name \"*.d.cts.map\" -delete",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "e2e": "playwright test",

--- a/packages/fastify/package.json
+++ b/packages/fastify/package.json
@@ -36,7 +36,7 @@
     "node": ">=22"
   },
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && find dist -name \"*.d.cts\" -delete && find dist -name \"*.d.cts.map\" -delete",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "e2e": "playwright test",

--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -36,7 +36,7 @@
     "node": ">=22"
   },
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && find dist -name \"*.d.cts\" -delete && find dist -name \"*.d.cts.map\" -delete",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "e2e": "playwright test",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -37,7 +37,7 @@
     "node": ">=22"
   },
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && find dist -name \"*.d.cts\" -delete && find dist -name \"*.d.cts.map\" -delete",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "e2e": "pnpm e2e:16 && pnpm e2e:15",


### PR DESCRIPTION
## Summary
\`tsup\` emits \`*.d.cts\` declaration files containing ESM \`import\` syntax. Turbopack 16's package scanner rejects them with:

\`\`\`
Specified module format (CommonJs) is not matching the module format of the source code (EcmaScript Modules)
\`\`\`

This breaks any Next 16 consumer that has \`@coraza/core\` (or any of our adapters) in \`node_modules/\` — i.e. every consumer who installs from npm/yarn/pnpm. Our internal compatibility matrix didn't catch it because workspace \`@coraza/core\` is a symlink, and Turbopack scans symlinks differently. The new \`matrix-pkg-managers.yml\` (PR #22) surfaced it.

\`exports.types\` already points only at \`.d.ts\`. TypeScript resolves type-only imports through it under both \`nodenext\` and \`bundler\` moduleResolution. The \`.d.cts\` files are dead weight.

## Fix
Append \`find dist -name '*.d.cts' -delete && find dist -name '*.d.cts.map' -delete\` to each publishable package's \`build\` script. Tried tsup's \`onSuccess\` hook first — it runs before dts emit completes, so the deletion missed. Post-build is reliable.

## Test plan
- [x] Local build: \`pnpm -F '@coraza/*' build\` — every package emits \`.d.ts\` only, zero \`.d.cts\` in any \`dist/\`
- [x] Local matrix: \`bash testing/matrix/scripts/run-local.sh\` — 20/20 legs green (regression check)
- [ ] CI: matrix-pkg-managers \`next16-proxy\` × {npm, yarn, pnpm} should now PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)