### PR TITLE
fix(coreruleset): #30 detect rule-id collisions in recommended({ extra })

### DIFF
--- a/.changeset/coreruleset-extra-id-collisions.md
+++ b/.changeset/coreruleset-extra-id-collisions.md
@@ -1,0 +1,28 @@
+---
+'@coraza/coreruleset': patch
+---
+
+`recommended({ extra })` (and the `balanced`/`strict`/`permissive` presets
+that delegate to it) now validates user-supplied SecLang for rule-id
+collisions instead of silently accepting them. Fixes #30.
+
+- Direct collisions with the ids `recommended()` itself emits
+  (`900000`–`900003`, depending on options) now **throw** at config-build
+  time with a message that names the colliding id, what the preset uses
+  it for, and which option to reach for instead. Example:
+  `rule id 900001 in `extra` collides with the recommended() preset
+  (it sets tx.inbound_anomaly_score_threshold). Pick an id >= 1,000,000
+  or override the threshold via the `inboundAnomalyScoreThreshold` option.`
+- Ids inside the CRS-reserved range `900000`–`999999` that are *not*
+  emitted by recommended() are still allowed (some advanced users
+  override CRS rules deliberately) but trigger a `console.warn` at
+  config time, since the chosen id may collide on a future CRS upgrade.
+- Ids `>= 1,000,000` (the documented user range) and `extra: ''` /
+  `extra: undefined` continue to pass silently.
+
+This is a runtime-behavior change — input that previously parsed (but
+silently produced an invalid SecLang blob with two `SecAction`s sharing
+an id) now throws. The previous behavior was a bug: depending on the
+engine's directive ordering, the user's override was either dead code or
+a load-time error. Surfacing the conflict at config time is strictly
+safer.

--- a/packages/coreruleset/src/index.ts
+++ b/packages/coreruleset/src/index.ts
@@ -156,9 +156,109 @@ function filesToSkip(
   return skip
 }
 
+// Maps each id `recommended()` itself emits to a short human-readable label
+// describing what it controls. Used to generate actionable error messages
+// when a user-supplied `extra` block reuses one of these ids.
+type EmittedDirective = { id: number; description: string }
+
+function emittedDirectives(opts: {
+  anomalyBlock: boolean
+}): EmittedDirective[] {
+  const list: EmittedDirective[] = [
+    { id: 900000, description: 'sets tx.blocking_paranoia_level' },
+    { id: 900001, description: 'sets tx.inbound_anomaly_score_threshold' },
+    { id: 900002, description: 'sets tx.outbound_anomaly_score_threshold' },
+  ]
+  if (!opts.anomalyBlock) {
+    list.push({ id: 900003, description: 'sets tx.early_blocking=0' })
+  }
+  return list
+}
+
+// Suggest the option a user should reach for instead of overriding via `extra`.
+const ID_TO_OPTION_HINT: Record<number, string> = {
+  900000: 'override the paranoia level via the `paranoia` option',
+  900001:
+    'override the threshold via the `inboundAnomalyScoreThreshold` option',
+  900002:
+    'override the threshold via the `outboundAnomalyScoreThreshold` option',
+  900003: 'toggle early blocking via the `anomalyBlock` option',
+}
+
+// Match `id:NNNN` tokens in SecLang. Tolerates whitespace around the colon
+// and requires a non-digit (or end of string) immediately after the digits
+// so `id:9000010` is NOT mis-parsed as `900001`. The leading lookbehind-ish
+// is replaced by an explicit non-digit / start-of-string check, since
+// JS lookbehind support is uneven across runtimes we support.
+const ID_TOKEN_RE = /(^|[^0-9A-Za-z_])id\s*:\s*(\d+)(?![0-9])/g
+
+/** Internal: extract every rule id referenced by an `extra` SecLang blob. */
+function extractRuleIds(extra: string): number[] {
+  const ids: number[] = []
+  let match: RegExpExecArray | null
+  ID_TOKEN_RE.lastIndex = 0
+  while ((match = ID_TOKEN_RE.exec(extra)) !== null) {
+    ids.push(Number.parseInt(match[2], 10))
+  }
+  return ids
+}
+
+/**
+ * Validate that no rule id in `extra` collides with the ids `recommended()`
+ * itself emits, and warn about ids in the CRS-reserved range. Throws on
+ * direct collisions. Exported (un-prefixed name) only for tests.
+ */
+function validateExtraIds(
+  extra: string,
+  emitted: EmittedDirective[],
+): void {
+  if (!extra || extra.trim().length === 0) return
+  const ids = extractRuleIds(extra)
+  if (ids.length === 0) return
+
+  const emittedById = new Map<number, EmittedDirective>(
+    emitted.map((d) => [d.id, d]),
+  )
+  for (const id of ids) {
+    const hit = emittedById.get(id)
+    if (hit) {
+      const hint = ID_TO_OPTION_HINT[id]
+      const tail = hint
+        ? `Pick an id >= 1,000,000 or ${hint}.`
+        : 'Pick an id >= 1,000,000.'
+      throw new Error(
+        `rule id ${id} in \`extra\` collides with the recommended() preset (it ${hit.description}). ${tail}`,
+      )
+    }
+  }
+
+  // CRS reserves 900000–999999. Ids outside the emitted set are not a hard
+  // collision today, but a user choosing one risks colliding on a future
+  // CRS upgrade. Warn but don't throw — see issue #30.
+  const warned = new Set<number>()
+  for (const id of ids) {
+    if (id < 900000 || id > 999999) continue
+    if (emittedById.has(id)) continue
+    if (warned.has(id)) continue
+    warned.add(id)
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[@coraza/coreruleset] rule id ${id} in \`extra\` is inside the CRS-reserved range (900000-999999). It does not currently collide with recommended(), but a future CRS upgrade may claim this id. Prefer ids >= 1,000,000 for user rules. See https://github.com/coraza-incubator/coraza-node/issues/30`,
+    )
+  }
+}
+
 /**
  * Build SecLang configuration that activates CRS with sensible defaults for
  * a Node.js application. Pass the return value as `rules` to `createWAF`.
+ *
+ * If `extra` is provided, its `id:N` tokens are validated against the ids
+ * `recommended()` itself emits (900000–900003 depending on options). A
+ * direct collision throws at config-build time with an actionable message.
+ * Ids inside the CRS-reserved range 900000–999999 that are not emitted by
+ * recommended() trigger a `console.warn` but are allowed (some advanced
+ * users override CRS rules deliberately). User rules belong at id >=
+ * 1,000,000.
  */
 export function recommended(options: CrsOptions = {}): string {
   const paranoia = options.paranoia ?? 1
@@ -168,6 +268,11 @@ export function recommended(options: CrsOptions = {}): string {
   const outbound = options.outboundAnomalyThreshold ?? 4
   const anomalyBlock = options.anomalyBlock ?? true
   const extra = options.extra ?? ''
+
+  // Validate before we build anything: a bad `extra` should fail loudly at
+  // config time, not silently produce an invalid SecLang blob.
+  const emitted = emittedDirectives({ anomalyBlock })
+  validateExtraIds(extra, emitted)
 
   const parts: string[] = []
   parts.push('Include @coraza.conf-recommended')
@@ -205,6 +310,9 @@ export function recommended(options: CrsOptions = {}): string {
   }
   return parts.join('\n') + '\n'
 }
+
+/** @internal — exposed only for tests. */
+export const __test = { extractRuleIds, validateExtraIds, emittedDirectives }
 
 /** Return a SecRuleRemoveById directive for a single category. Low-level. */
 export function excludeCategory(cat: CrsCategory): string {

--- a/packages/coreruleset/src/index.ts
+++ b/packages/coreruleset/src/index.ts
@@ -198,7 +198,7 @@ function extractRuleIds(extra: string): number[] {
   let match: RegExpExecArray | null
   ID_TOKEN_RE.lastIndex = 0
   while ((match = ID_TOKEN_RE.exec(extra)) !== null) {
-    ids.push(Number.parseInt(match[2], 10))
+    ids.push(Number.parseInt(match[2]!, 10))
   }
   return ids
 }

--- a/packages/coreruleset/test/index.test.ts
+++ b/packages/coreruleset/test/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import {
   recommended,
   balanced,
@@ -7,6 +7,7 @@ import {
   excludeByTag,
   excludeCategory,
   paranoia,
+  __test,
 } from '../src/index.js'
 
 describe('recommended()', () => {
@@ -185,6 +186,137 @@ describe('low-level helpers', () => {
     expect(excludeCategory('scanner-detection')).toBe('SecRuleRemoveById 910000-913999')
     expect(excludeCategory('dos-protection')).toBe('SecRuleRemoveById 912000-912999')
     expect(excludeCategory('outbound-data-leak')).toBe('SecRuleRemoveById 950000-950999')
+  })
+})
+
+describe('recommended() — extra id-collision validation (issue #30)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('throws when extra reuses an id emitted by recommended() (900001)', () => {
+    expect(() =>
+      recommended({
+        extra:
+          'SecAction "id:900001,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=10"',
+      }),
+    ).toThrow(/rule id 900001 in `extra` collides with the recommended\(\) preset/)
+  })
+
+  it('error message names the colliding id and the option to use instead', () => {
+    let caught: Error | null = null
+    try {
+      recommended({
+        extra:
+          'SecAction "id:900001,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=10"',
+      })
+    } catch (err) {
+      caught = err as Error
+    }
+    expect(caught).not.toBeNull()
+    expect(caught!.message).toContain('900001')
+    expect(caught!.message).toContain('tx.inbound_anomaly_score_threshold')
+    expect(caught!.message).toContain('inboundAnomalyScoreThreshold')
+  })
+
+  it('throws on collision with id 900000 (paranoia)', () => {
+    expect(() =>
+      recommended({
+        extra: 'SecAction "id:900000,phase:1,nolog,pass,t:none,setvar:tx.blocking_paranoia_level=4"',
+      }),
+    ).toThrow(/rule id 900000/)
+  })
+
+  it('throws on collision with 900003 only when it is actually emitted (anomalyBlock=false)', () => {
+    // anomalyBlock=true (default): 900003 is NOT emitted, so it should NOT throw —
+    // it falls into the "warn" path below.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(() =>
+      recommended({
+        extra: 'SecAction "id:900003,phase:1,nolog,pass,t:none,setvar:tx.early_blocking=0"',
+      }),
+    ).not.toThrow()
+    warn.mockRestore()
+
+    // anomalyBlock=false: 900003 IS emitted, so it must throw.
+    expect(() =>
+      recommended({
+        anomalyBlock: false,
+        extra: 'SecAction "id:900003,phase:1,nolog,pass,t:none,setvar:tx.early_blocking=0"',
+      }),
+    ).toThrow(/rule id 900003/)
+  })
+
+  it('warns (does not throw) for ids in 900000-999999 that recommended() does not emit', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(() =>
+      recommended({
+        extra:
+          'SecAction "id:950000,phase:1,nolog,pass,t:none,setvar:tx.foo=1"',
+      }),
+    ).not.toThrow()
+    expect(warn).toHaveBeenCalledTimes(1)
+    expect(warn.mock.calls[0]?.[0]).toContain('950000')
+    expect(warn.mock.calls[0]?.[0]).toContain('CRS-reserved')
+  })
+
+  it('passes silently for ids >= 1,000,000 (the documented user range)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(() =>
+      recommended({
+        extra: 'SecRule REQUEST_URI "@contains /admin" "id:1000000,deny,status:403"',
+      }),
+    ).not.toThrow()
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('extra: "" passes without scanning', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(() => recommended({ extra: '' })).not.toThrow()
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('extra: undefined passes without scanning', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(() => recommended({})).not.toThrow()
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('id token regex tolerates whitespace and trailing comma', () => {
+    expect(__test.extractRuleIds('id : 900001 ,phase:1')).toEqual([900001])
+    expect(__test.extractRuleIds('"id:1234,phase:1"')).toEqual([1234])
+    expect(__test.extractRuleIds('  id:42 ')).toEqual([42])
+  })
+
+  it('id token regex does not mis-parse 9000010 as 900001 (boundary)', () => {
+    // Critical: substring matching would falsely trigger a collision on
+    // legal id 9000010. The regex must match whole-id only.
+    expect(__test.extractRuleIds('SecAction "id:9000010,phase:1"')).toEqual([
+      9000010,
+    ])
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(() =>
+      recommended({
+        extra: 'SecAction "id:9000010,phase:1,nolog,pass,t:none,setvar:tx.x=1"',
+      }),
+    ).not.toThrow()
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('does not match `id:` inside an unrelated identifier (e.g. `myid:900001`)', () => {
+    // The leading non-ident-char guard means `myid:900001` should not parse
+    // as a rule id. (It's not valid SecLang anyway, but the regex must be
+    // robust against incidental substrings.)
+    expect(__test.extractRuleIds('myid:900001')).toEqual([])
+  })
+
+  it('extracts multiple ids and reports the first collision found', () => {
+    expect(() =>
+      recommended({
+        extra:
+          'SecRule REQUEST_URI "@contains /a" "id:1000001,deny"\nSecAction "id:900002,phase:1,nolog,pass,t:none,setvar:tx.outbound_anomaly_score_threshold=99"',
+      }),
+    ).toThrow(/rule id 900002/)
   })
 })
 


### PR DESCRIPTION
Closes #30.

## Issue

> `recommended({ extra })` concatenates the user-supplied `extra` SecLang block after CRS includes. There is no validation that `extra` doesn't reuse rule ids that `recommended()` itself emits. Specifically the helper unconditionally generates `SecAction id:900000..900003`. If a user passes `extra: 'SecAction \"id:900001,...,setvar:tx.inbound_anomaly_score_threshold=10\"'` thinking they're overriding the threshold, what actually happens is undefined… they get the recommended() value silently, and their override is dead code.

## What shipped

- `recommended({ extra })` now scans `extra` for `id:N` tokens and:
  - **Throws** on a collision with any id `recommended()` itself emits (`900000`/`900001`/`900002`, plus `900003` when `anomalyBlock: false`). The set is built programmatically from the same options that drive emission, so it stays in sync.
  - **Warns** (`console.warn`) — but does not throw — for ids in the CRS-reserved range `900000`–`999999` that aren't currently emitted; these are still allowed (some advanced users override CRS rules deliberately) but a future CRS upgrade may claim the id.
  - Ids `>= 1,000,000` (the documented user range), and `extra: ''` / `extra: undefined`, pass silently.
- The id-token regex (`/(^|[^0-9A-Za-z_])id\s*:\s*(\d+)(?![0-9])/g`) tolerates whitespace around the colon and trailing commas (so `id : 1234 ,` parses as `1234`) and uses a non-digit boundary so `id:9000010` is not mis-parsed as `900001`.
- Patch changeset documents the runtime-behavior change (previously-silent invalid input now throws — the prior behavior was a bug).

## Tests

In `packages/coreruleset/test/index.test.ts`, suite `recommended() — extra id-collision validation (issue #30)`:

- `throws when extra reuses an id emitted by recommended() (900001)`
- `error message names the colliding id and the option to use instead`
- `throws on collision with id 900000 (paranoia)`
- `throws on collision with 900003 only when it is actually emitted (anomalyBlock=false)`
- `warns (does not throw) for ids in 900000-999999 that recommended() does not emit`
- `passes silently for ids >= 1,000,000 (the documented user range)`
- `extra: \"\" passes without scanning`
- `extra: undefined passes without scanning`
- `id token regex tolerates whitespace and trailing comma`
- `id token regex does not mis-parse 9000010 as 900001 (boundary)`
- `does not match id: inside an unrelated identifier (e.g. myid:900001)`
- `extracts multiple ids and reports the first collision found`

## Test plan

- [x] `pnpm -F @coraza/coreruleset test` — 42 passed (12 new)
- [x] No core or adapter packages touched
- [x] Patch changeset added, no `--no-verify`