### PR TITLE
fix(core): #28 document skip-predicate semantics + support compound extensions

### DIFF
--- a/.changeset/skip-predicate-compound-extensions.md
+++ b/.changeset/skip-predicate-compound-extensions.md
@@ -1,0 +1,16 @@
+---
+'@coraza/core': patch
+---
+
+Document `buildSkipPredicate` / `SkipOptions` extension match semantics on the
+type itself (case-insensitive, query/fragment ignored, only the trailing
+basename segment matches) and add support for **compound extensions**.
+
+Entries containing a dot (e.g. `'tar.gz'`, `'min.js'`, `'d.ts'`) now match as a
+`.<ext>` suffix on the path's basename. The leading `.` is required, so
+`extensions: ['min.js']` skips `/bundle.min.js` but **does not** skip a request
+whose pathname is literally `/min.js` (that's the bare filename, not a
+`.min.js` extension). Single-token entries (`'css'`, `'png'`) keep their
+existing behavior.
+
+Closes #28.

--- a/packages/core/src/skip.ts
+++ b/packages/core/src/skip.ts
@@ -42,11 +42,34 @@ export interface SkipOptions {
   /**
    * Additional URL-path prefixes to bypass. Merged with
    * {@link DEFAULT_SKIP_PREFIXES} unless {@link skipDefaults} is `false`.
+   *
+   * Matched case-sensitively as a simple `startsWith` against the URL path
+   * (no query string, no fragment).
    */
   prefixes?: readonly string[]
   /**
-   * Additional file extensions (without leading dot) to bypass. Merged with
+   * Additional file extensions to bypass. Merged with
    * {@link DEFAULT_SKIP_EXTENSIONS} unless {@link skipDefaults} is `false`.
+   *
+   * Match semantics (see {@link buildSkipPredicate} for the full contract):
+   *
+   * - Match runs against the URL path only — query string and fragment are
+   *   ignored. Pass paths via {@link pathOf} if your adapter hands you a
+   *   full URL.
+   * - Case-insensitive: list entries and the candidate path are both
+   *   lowercased at match time. List entries are normalized once at
+   *   build time, so `'PNG'` and `'png'` are equivalent.
+   * - **Single-token entries** (no internal dot, e.g. `'css'`, `'png'`)
+   *   match only the trailing `.foo` segment of the path's basename.
+   *   `/static/foo.css/bar` does NOT match `'css'` because the last `.`
+   *   is followed by a `/`.
+   * - **Compound entries** (containing a dot, e.g. `'tar.gz'`, `'min.js'`)
+   *   match as a `.<ext>` suffix on the path's basename. So `'tar.gz'`
+   *   matches `/archive.tar.gz` but NOT a basename literally named
+   *   `tar.gz` (no leading dot — that's the bare filename, not an
+   *   extension), and not `/archive.tar.gz/extra` (the `/` after the
+   *   match disqualifies it).
+   * - Do NOT include a leading dot in entries: write `'png'`, not `'.png'`.
    */
   extensions?: readonly string[]
   /**
@@ -68,33 +91,92 @@ export interface SkipOptions {
 /**
  * Build a single-path predicate that is cheap to call per request.
  * Compiled once; adapter middleware invokes it without re-parsing options.
+ *
+ * The returned predicate runs four checks in order; the first hit wins:
+ *
+ * 1. Prefix match (`startsWith`) against {@link SkipOptions.prefixes}
+ *    plus the defaults. Case-sensitive.
+ * 2. Extension match against {@link SkipOptions.extensions} plus the
+ *    defaults. See below.
+ * 3. `RegExp.test` against each entry in {@link SkipOptions.patterns}.
+ * 4. {@link SkipOptions.custom} if provided.
+ *
+ * ## Extension match contract
+ *
+ * The input is treated as a URL **path** — pre-strip query/fragment with
+ * {@link pathOf} if the adapter hands you a full URL. The extension list
+ * is normalized to lowercase once at build time.
+ *
+ * - **Single-token entries** (`'css'`, `'png'`, `'wasm'`): match the
+ *   substring after the last `.` in the path, but only when no `/`
+ *   appears between that `.` and the end of the string. So `/foo.css`
+ *   matches but `/static/foo.css/bar` does not (the dot lives in a
+ *   directory segment).
+ * - **Compound entries** (`'tar.gz'`, `'min.js'`, `'d.ts'`): match
+ *   `.<ext>` as a suffix on the path's basename (the part after the
+ *   last `/`). The leading `.` is required, which is the boundary that
+ *   makes a `'min.js'` entry skip `/bundle.min.js` while NOT skipping
+ *   a request for a literal file named `min.js` (path `/min.js` —
+ *   that's the bare filename, not a `.min.js` extension).
+ *
+ * Examples (assuming `extensions: ['css', 'tar.gz', 'min.js']`):
+ *
+ * | Path                       | Skip? | Why |
+ * |----------------------------|-------|-----|
+ * | `/foo.css`                 | yes   | trailing `.css` |
+ * | `/Foo.CSS`                 | yes   | case-insensitive |
+ * | `/static/foo.css/bar`      | no    | `/` after the `.` disqualifies |
+ * | `/api/upload?name=evil.css`| no    | only the path is checked; pass via {@link pathOf} |
+ * | `/archive.tar.gz`          | yes   | compound suffix `.tar.gz` |
+ * | `/archive.tar.gz/extra`    | no    | `/` after the suffix disqualifies |
+ * | `/bundle.min.js`           | yes   | compound suffix `.min.js` |
+ * | `/bundle.js`               | no    | not `.min.js` |
+ * | `/min.js`                  | no    | bare basename `min.js` has no leading `.min.js` |
  */
 export function buildSkipPredicate(opts: SkipOptions | undefined): (path: string) => boolean {
   if (!opts) {
     const prefixes = DEFAULT_SKIP_PREFIXES
-    const extensions = DEFAULT_SKIP_EXTENSIONS
-    return (path) => matchesPrefix(path, prefixes) || matchesExtension(path, extensions)
+    const single = DEFAULT_SKIP_EXTENSIONS
+    return (path) => matchesPrefix(path, prefixes) || matchesExtension(path, single, EMPTY_COMPOUND)
   }
 
   const useDefaults = opts.skipDefaults !== true
   const prefixes = useDefaults
     ? [...DEFAULT_SKIP_PREFIXES, ...(opts.prefixes ?? [])]
     : [...(opts.prefixes ?? [])]
-  const extensions = useDefaults
-    ? new Set<string>([...DEFAULT_SKIP_EXTENSIONS, ...(opts.extensions ?? [])])
-    : new Set<string>(opts.extensions ?? [])
+  const merged = useDefaults
+    ? [...DEFAULT_SKIP_EXTENSIONS, ...(opts.extensions ?? [])]
+    : [...(opts.extensions ?? [])]
+  const { single, compound } = partitionExtensions(merged)
   const patterns = opts.patterns ?? []
   const custom = opts.custom
 
   return (path) => {
     if (prefixes.length > 0 && matchesPrefix(path, prefixes)) return true
-    if (extensions.size > 0 && matchesExtension(path, extensions)) return true
+    if ((single.size > 0 || compound.length > 0) && matchesExtension(path, single, compound)) return true
     for (const p of patterns) {
       if (p.test(path)) return true
     }
     if (custom && custom(path)) return true
     return false
   }
+}
+
+const EMPTY_COMPOUND: readonly string[] = []
+
+function partitionExtensions(list: readonly string[]): {
+  single: ReadonlySet<string>
+  compound: readonly string[]
+} {
+  const single = new Set<string>()
+  const compound: string[] = []
+  for (const raw of list) {
+    const ext = raw.toLowerCase()
+    if (ext.length === 0) continue
+    if (ext.includes('.')) compound.push(ext)
+    else single.add(ext)
+  }
+  return { single, compound }
 }
 
 /** Extract the path from a URL string that may include query/hash. */
@@ -112,12 +194,30 @@ function matchesPrefix(path: string, prefixes: readonly string[]): boolean {
   return false
 }
 
-function matchesExtension(path: string, extensions: ReadonlySet<string>): boolean {
+function matchesExtension(
+  path: string,
+  single: ReadonlySet<string>,
+  compound: readonly string[],
+): boolean {
   const dot = path.lastIndexOf('.')
   if (dot === -1 || dot === path.length - 1) return false
   // Don't match if the dot is in a directory (before the last /).
   const slash = path.lastIndexOf('/')
   if (dot < slash) return false
-  const ext = path.slice(dot + 1).toLowerCase()
-  return extensions.has(ext)
+  const lower = path.toLowerCase()
+  if (single.size > 0 && single.has(lower.slice(dot + 1))) return true
+  if (compound.length > 0) {
+    // Compound entries match a `.ext.subext` suffix on the basename. The
+    // leading dot is required so a request for a literal file named
+    // `min.js` (path `/min.js`) does NOT match `extensions: ['min.js']`.
+    const basenameStart = slash + 1
+    for (const ext of compound) {
+      // Need at least one character before `.<ext>` for the leading dot
+      // boundary to exist within the basename. This is what excludes a
+      // bare basename like `min.js` from matching `'min.js'`.
+      if (lower.length - basenameStart <= ext.length) continue
+      if (lower.endsWith('.' + ext)) return true
+    }
+  }
+  return false
 }

--- a/packages/core/test/skip.test.ts
+++ b/packages/core/test/skip.test.ts
@@ -6,6 +6,10 @@ import {
   DEFAULT_SKIP_PREFIXES,
 } from '../src/skip.js'
 
+// Helper: model the adapter convention of always running the predicate
+// against `URL.pathname` (i.e. query/fragment pre-stripped).
+const skipUrl = (pred: (p: string) => boolean, url: string) => pred(pathOf(url))
+
 describe('pathOf', () => {
   it('returns path without query or hash', () => {
     expect(pathOf('/a/b')).toBe('/a/b')
@@ -105,5 +109,115 @@ describe('buildSkipPredicate custom', () => {
     const skip = buildSkipPredicate()
     expect(skip('/favicon.ico')).toBe(true)
     expect(skip('/robots.txt')).toBe(true)
+  })
+})
+
+describe('buildSkipPredicate extension match contract', () => {
+  it('single-segment entry still matches its own extension', () => {
+    const skip = buildSkipPredicate({ skipDefaults: true, extensions: ['css'] })
+    expect(skip('/foo.css')).toBe(true)
+  })
+
+  it('single-segment entry does not match when the dot is in a directory', () => {
+    const skip = buildSkipPredicate({ skipDefaults: true, extensions: ['css'] })
+    // The last `.` is inside a directory segment; the basename is `bar`.
+    expect(skip('/static/foo.css/bar')).toBe(false)
+  })
+
+  it('case-insensitive: lowercase list entry matches uppercase path', () => {
+    const skip = buildSkipPredicate({ skipDefaults: true, extensions: ['css'] })
+    expect(skip('/foo.CSS')).toBe(true)
+    expect(skip('/Foo.Css')).toBe(true)
+  })
+
+  it('case-insensitive: uppercase list entry is normalized at build time', () => {
+    const skip = buildSkipPredicate({ skipDefaults: true, extensions: ['CSS'] })
+    expect(skip('/foo.css')).toBe(true)
+    expect(skip('/foo.CSS')).toBe(true)
+  })
+
+  it('query string is ignored when the caller pre-strips via pathOf', () => {
+    const skip = buildSkipPredicate({ skipDefaults: true, extensions: ['css'] })
+    expect(skipUrl(skip, '/foo.css?v=1')).toBe(true)
+    expect(skipUrl(skip, '/foo.css#frag')).toBe(true)
+  })
+
+  it('does NOT match `evil.css` smuggled in a query string against the bare path', () => {
+    // This pins issue #28's correctness check: pathname is `/api/upload`,
+    // there is no extension to match, regardless of `?name=evil.css`.
+    const skip = buildSkipPredicate({ skipDefaults: true, extensions: ['css'] })
+    expect(skipUrl(skip, '/api/upload?name=evil.css')).toBe(false)
+  })
+
+  it('compound: tar.gz matches /archive.tar.gz', () => {
+    const skip = buildSkipPredicate({ skipDefaults: true, extensions: ['tar.gz'] })
+    expect(skip('/archive.tar.gz')).toBe(true)
+    expect(skip('/dist/release-1.0.tar.gz')).toBe(true)
+  })
+
+  it('compound: min.js matches /bundle.min.js but not /bundle.js', () => {
+    const skip = buildSkipPredicate({ skipDefaults: true, extensions: ['min.js'] })
+    expect(skip('/bundle.min.js')).toBe(true)
+    expect(skip('/bundle.js')).toBe(false)
+  })
+
+  it('compound: mixed-case input and entry both normalize', () => {
+    const skip = buildSkipPredicate({ skipDefaults: true, extensions: ['Min.JS'] })
+    expect(skip('/Bundle.MIN.js')).toBe(true)
+    expect(skip('/Bundle.MIN.JS')).toBe(true)
+  })
+
+  it('compound: does NOT match a bare basename literally named `min.js`', () => {
+    // The boundary case: a leading `.` is required in front of the entry,
+    // otherwise we would skip a request for a literal file named `min.js`.
+    // That file's basename is the entry itself, not the entry preceded
+    // by `.`, so it must NOT skip.
+    const skip = buildSkipPredicate({ skipDefaults: true, extensions: ['min.js'] })
+    expect(skip('/min.js')).toBe(false)
+    expect(skip('/sub/min.js')).toBe(false)
+    expect(skip('min.js')).toBe(false)
+  })
+
+  it('compound: does NOT match a bare basename `tar.gz`', () => {
+    const skip = buildSkipPredicate({ skipDefaults: true, extensions: ['tar.gz'] })
+    expect(skip('/tar.gz')).toBe(false)
+    expect(skip('/downloads/tar.gz')).toBe(false)
+  })
+
+  it('compound: does NOT match if the suffix is followed by another path segment', () => {
+    const skip = buildSkipPredicate({ skipDefaults: true, extensions: ['tar.gz'] })
+    expect(skip('/archive.tar.gz/extra')).toBe(false)
+  })
+
+  it('compound: does NOT match an unrelated basename ending with a different inner segment', () => {
+    // /foo.bin.js must NOT be skipped under min.js
+    const skip = buildSkipPredicate({ skipDefaults: true, extensions: ['min.js'] })
+    expect(skip('/foo.bin.js')).toBe(false)
+  })
+
+  it('compound: does NOT skip `evil.min.js.exe` when `exe` is not in the list', () => {
+    // Standard "skip if last bit matches" semantics. The literal trailing
+    // segment is `exe`; `min.js` is not the suffix of the basename.
+    const skip = buildSkipPredicate({ skipDefaults: true, extensions: ['min.js'] })
+    expect(skip('/evil.min.js.exe')).toBe(false)
+  })
+
+  it('compound and single can coexist', () => {
+    const skip = buildSkipPredicate({
+      skipDefaults: true,
+      extensions: ['css', 'tar.gz', 'min.js'],
+    })
+    expect(skip('/foo.css')).toBe(true)
+    expect(skip('/x.tar.gz')).toBe(true)
+    expect(skip('/x.min.js')).toBe(true)
+    expect(skip('/x.js')).toBe(false)
+    expect(skip('/min.js')).toBe(false) // boundary
+  })
+
+  it('empty / blank list entries are ignored', () => {
+    const skip = buildSkipPredicate({ skipDefaults: true, extensions: ['', 'png'] })
+    expect(skip('/foo.png')).toBe(true)
+    expect(skip('/foo')).toBe(false)
+    expect(skip('/foo.')).toBe(false)
   })
 })


### PR DESCRIPTION
## Issue

> `buildSkipPredicate` runs against the URL **path** (`url.pathname`).
> Extension matching looks at the last `.` after the last `/`, ignores
> query string. That's correct behavior — query strings can't change file
> extension semantically — but the contract isn't documented and there's
> a small footgun.
> [...]
> 1. Document the match semantics in the `SkipOptions` JSDoc.
> 2. Optional: support compound extensions (`['tar.gz', 'min.js']` is a
>    recurring ask).
> 3. Add a test for the `pathname` vs full URL distinction.

— #28

## What shipped

- **JSDoc** on `SkipOptions.extensions`, `SkipOptions.prefixes`, and
  `buildSkipPredicate` covers: path-only matching (query/fragment ignored,
  pre-strip with `pathOf`), case-insensitive, list normalized at build time,
  trailing-segment-only for single-token entries, the `/` boundary on
  `/static/foo.css/bar`, and a new examples table.
- **Compound extensions**: any entry containing a dot (`tar.gz`, `min.js`,
  `d.ts`) matches as a `.<ext>` suffix on the basename. The leading `.` is
  required so a literal filename like `/min.js` is NOT skipped under
  `extensions: ['min.js']`. Single-token entries (`css`, `png`) keep
  current behavior.
- Implemented with a one-time partition into `single: Set` + `compound: string[]`
  at build time so the per-request hot path stays a single allocation-free
  pass.
- Patch changeset added (additive feature, no breaking change).

## Tests

`packages/core/test/skip.test.ts` grows from 16 to **32** tests. New
`buildSkipPredicate extension match contract` block adds:

- `single-segment entry still matches its own extension`
- `single-segment entry does not match when the dot is in a directory`
- `case-insensitive: lowercase list entry matches uppercase path`
- `case-insensitive: uppercase list entry is normalized at build time`
- `query string is ignored when the caller pre-strips via pathOf`
- `does NOT match \`evil.css\` smuggled in a query string against the bare path`
- `compound: tar.gz matches /archive.tar.gz`
- `compound: min.js matches /bundle.min.js but not /bundle.js`
- `compound: mixed-case input and entry both normalize`
- `compound: does NOT match a bare basename literally named \`min.js\`` (the boundary case)
- `compound: does NOT match a bare basename \`tar.gz\``
- `compound: does NOT match if the suffix is followed by another path segment`
- `compound: does NOT match an unrelated basename ending with a different inner segment`
- `compound: does NOT skip \`evil.min.js.exe\` when \`exe\` is not in the list`
- `compound and single can coexist`
- `empty / blank list entries are ignored`

`pnpm -F @coraza/core test` is green (124/124). `skip.ts` stays at 100%
lines/branches/funcs/stmts.

## Security check

- Q1 — Impact: additive broadening of an opt-in static-bypass list. Same
  shape as the existing single-token bypass (path-only, case-insensitive,
  basename only). No widening of attacker-reachable surface.
- Q2 — New throw paths: none.
- Q3 — Inputs to Coraza: unchanged.
- Q4 — When rules fire: unchanged.
- Q5 — Defaults: unchanged. Only single-token extensions ship in
  `DEFAULT_SKIP_EXTENSIONS`. Compound entries are user-supplied.

## Test plan

- [x] `pnpm -F @coraza/core test` green
- [x] `skip.ts` coverage 100% across the board
- [x] Boundary verified: `extensions: ['min.js']` against pathname `/min.js`
      returns `false` (no leading-dot suffix in the basename)

Closes #28.