### PR TITLE
fix(adapters): #23 expose matched rules in block log

### DIFF
--- a/.changeset/issue-23-block-log-matched-rules.md
+++ b/.changeset/issue-23-block-log-matched-rules.md
@@ -1,0 +1,15 @@
+---
+'@coraza/next': patch
+'@coraza/express': patch
+'@coraza/fastify': patch
+'@coraza/nestjs': patch
+---
+
+Surface contributing rules in the block log. The default block-log line
+now includes `interruption.data` (the WAF has already populated it — for
+CRS this is the human-readable reason, e.g. `Inbound Anomaly Score
+Exceeded (Total Score: 10)`). A new `verboseLog?: boolean` option emits
+one `coraza: matched` line per contributing rule and exposes the matched
+rules to a custom `onBlock` via an optional `ctx.matchedRules` argument.
+Default is `false`; opting in costs one extra `tx.matchedRules()`
+round-trip per block. Closes #23.

--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -22,6 +22,7 @@ import type {
   Transaction,
   Interruption,
   Logger,
+  MatchedRule,
   RequestInfo,
   SkipOptions,
   IgnoreSpec,
@@ -44,8 +45,17 @@ export interface CorazaExpressOptions {
   /**
    * Override how a block decision is turned into an HTTP response.
    * Default: sets status + plain-text body with the interruption's rule id.
+   *
+   * The optional `ctx.matchedRules` lists every rule that matched in the
+   * transaction (only populated when `verboseLog: true`, otherwise
+   * `undefined` to avoid the WASM round-trip on every block).
    */
-  onBlock?: (interruption: Interruption, req: Request, res: Response) => void
+  onBlock?: (
+    interruption: Interruption,
+    req: Request,
+    res: Response,
+    ctx?: CorazaBlockContext,
+  ) => void
   /**
    * Inspect the response phase (headers + body) in addition to the request.
    * Default: `false`. Response inspection doubles per-request work; enable
@@ -81,6 +91,22 @@ export interface CorazaExpressOptions {
    *             Matches what a dedicated WAF sidecar would do.
    */
   onWAFError?: 'allow' | 'block'
+  /**
+   * When `true`, emit one `log.warn('coraza: matched', { ... })` per
+   * matched rule on a block (ModSecurity error.log style). Adds an
+   * extra `tx.matchedRules()` read on the block path; default `false`.
+   * The default block log always includes `interruption.data`.
+   */
+  verboseLog?: boolean
+}
+
+/**
+ * Optional context handed to `onBlock` as a fourth argument. Only
+ * populated when `verboseLog: true` (the runner pre-fetches matched
+ * rules for the verbose log path and re-uses them here).
+ */
+export interface CorazaBlockContext {
+  matchedRules: MatchedRule[]
 }
 
 type ReqWithLog = Request & { log?: Logger }
@@ -93,6 +119,7 @@ export function coraza(options: CorazaExpressOptions): RequestHandler {
     onBlock = defaultBlock,
     inspectResponse = false,
     onWAFError = 'block',
+    verboseLog = false,
   } = options
   const matcher = resolveIgnoreMatcher(options.ignore, options.skip)
 
@@ -187,7 +214,7 @@ export function coraza(options: CorazaExpressOptions): RequestHandler {
       const bodyBuf = verdict === 'skip-body' ? undefined : extractBody(req)
       const interrupted = await tx.processRequestBundle(reqInfo, bodyBuf)
       if (interrupted) {
-        return emitBlock(await tx.interruption(), req, res, onBlock, log)
+        return emitBlock(await tx.interruption(), req, res, onBlock, log, tx, verboseLog)
       }
 
       if (inspectResponse) {
@@ -195,7 +222,17 @@ export function coraza(options: CorazaExpressOptions): RequestHandler {
         // only work with the sync `WAF` path — a pool's async methods can't
         // block mid-write. Skip quietly under pools; log once so users know.
         if (isSyncTx(tx)) {
-          hookResponse(tx, res, (it) => emitBlock(it, req, res, onBlock, log), log)
+          hookResponse(
+            tx,
+            res,
+            (it) => {
+              // Sync-only path; emit synchronously so we don't return a
+              // Promise from res.writeHead/res.end.
+              const mr = verboseLog ? tx.matchedRules() : undefined
+              if (it) emitBlockSync(it, req, res, onBlock, log, mr)
+            },
+            log,
+          )
         } else {
           log.warn(
             'coraza: inspectResponse=true is a no-op when using WAFPool; use a single WAF or drop response inspection',
@@ -300,21 +337,49 @@ export function defaultBlock(interruption: Interruption, _req: Request, res: Res
     .send(`Request blocked by Coraza (rule ${interruption.ruleId})\n`)
 }
 
-function emitBlock(
+async function emitBlock(
   interruption: Interruption | null,
   req: Request,
   res: Response,
   onBlock: NonNullable<CorazaExpressOptions['onBlock']>,
   log: Logger,
-): void {
+  tx: AnyTransaction,
+  verboseLog: boolean,
+): Promise<void> {
   /* c8 ignore next — defensive: tx_has_interrupt=1 but get_interrupt=null is a bug */
   if (!interruption) return
+  const matched = verboseLog ? await tx.matchedRules() : undefined
+  emitBlockSync(interruption, req, res, onBlock, log, matched)
+}
+
+function emitBlockSync(
+  interruption: Interruption,
+  req: Request,
+  res: Response,
+  onBlock: NonNullable<CorazaExpressOptions['onBlock']>,
+  log: Logger,
+  matched: MatchedRule[] | undefined,
+): void {
   log.warn('coraza: request blocked', {
     ruleId: interruption.ruleId,
     status: interruption.status,
     action: interruption.action,
+    ...(interruption.data ? { data: interruption.data } : {}),
   })
-  onBlock(interruption, req, res)
+  if (matched) {
+    for (const r of matched) {
+      log.warn('coraza: matched', {
+        ruleId: r.id,
+        severity: r.severity,
+        msg: r.message,
+      })
+    }
+    onBlock(interruption, req, res, { matchedRules: matched })
+  } else {
+    // Don't pass `undefined` as a 4th arg — keeps toHaveBeenCalledWith(it, req, res)
+    // assertions in pre-existing consumer tests stable.
+    onBlock(interruption, req, res)
+  }
 }
 
 function headersOf(

--- a/packages/express/test/middleware.test.ts
+++ b/packages/express/test/middleware.test.ts
@@ -622,4 +622,44 @@ describe('@coraza/express', () => {
     app.get('/img/logo.png', (_req, res) => res.send('ok'))
     expect((await request(app).get('/img/logo.png')).status).toBe(403)
   })
+
+  // Issue #23 — block log loses signal. The default line MUST include
+  // `interruption.data` (free, the WASM has already populated it) and
+  // verboseLog MUST surface contributing matched rules so a CRS 949110
+  // anomaly-score block tells you which underlying rules tripped.
+  it('issue #23: default block log includes interruption.data and verboseLog emits matched rules', async () => {
+    const { waf } = mockWAF('block', {
+      onHeaders: (tx) => {
+        tx.matchedRules = [
+          { id: 942100, severity: 2, message: 'SQL Injection (libinjection)' },
+          { id: 941100, severity: 2, message: 'XSS reflected' },
+        ]
+        return {
+          ruleId: 949110,
+          action: 'deny',
+          status: 403,
+          data: 'Inbound Anomaly Score Exceeded (Total Score: 10)',
+        }
+      },
+    })
+    const warn = vi.fn()
+    waf.logger = { ...waf.logger, warn }
+    const app = appWith(coraza({ waf, verboseLog: true }))
+    await request(app).get('/hi')
+    expect(warn).toHaveBeenCalledWith(
+      'coraza: request blocked',
+      expect.objectContaining({
+        ruleId: 949110,
+        data: 'Inbound Anomaly Score Exceeded (Total Score: 10)',
+      }),
+    )
+    expect(warn).toHaveBeenCalledWith(
+      'coraza: matched',
+      expect.objectContaining({ ruleId: 942100, severity: 2, msg: 'SQL Injection (libinjection)' }),
+    )
+    expect(warn).toHaveBeenCalledWith(
+      'coraza: matched',
+      expect.objectContaining({ ruleId: 941100 }),
+    )
+  })
 })

--- a/packages/fastify/src/index.ts
+++ b/packages/fastify/src/index.ts
@@ -29,6 +29,7 @@ import type {
   Transaction,
   WorkerTransaction,
   Interruption,
+  MatchedRule,
   SkipOptions,
   IgnoreSpec,
   IgnoreContext,
@@ -44,10 +45,16 @@ export interface CorazaFastifyOptions {
    * defer construction.
    */
   waf: WAFLike
+  /**
+   * Override how a block decision is turned into a Fastify reply.
+   * The optional `ctx.matchedRules` lists every rule that matched in
+   * the transaction (only populated when `verboseLog: true`).
+   */
   onBlock?: (
     interruption: Interruption,
     req: FastifyRequest,
     reply: FastifyReply,
+    ctx?: CorazaBlockContext,
   ) => void | Promise<void>
   /** Run phase 3+4 on the response. Default false; see @coraza/express docs. */
   inspectResponse?: boolean
@@ -66,6 +73,20 @@ export interface CorazaFastifyOptions {
    *                       setups; document why you flipped it.
    */
   onWAFError?: 'allow' | 'block'
+  /**
+   * When `true`, emit one `log.warn('coraza: matched', { ... })` per
+   * matched rule on a block. Default `false`. The default block log
+   * always includes `interruption.data`.
+   */
+  verboseLog?: boolean
+}
+
+/**
+ * Optional context handed to `onBlock` as a fourth argument. Only
+ * populated when `verboseLog: true`.
+ */
+export interface CorazaBlockContext {
+  matchedRules: MatchedRule[]
 }
 
 const TX_SYMBOL = Symbol('coraza.tx')
@@ -78,6 +99,7 @@ const pluginImpl: FastifyPluginAsync<CorazaFastifyOptions> = async (fastify, opt
     onBlock = defaultBlock,
     inspectResponse = false,
     onWAFError = 'block',
+    verboseLog = false,
   } = opts
   const matcher = resolveIgnoreMatcher(opts.ignore, opts.skip)
 
@@ -109,6 +131,8 @@ const pluginImpl: FastifyPluginAsync<CorazaFastifyOptions> = async (fastify, opt
           req,
           reply,
           onBlock,
+          null,
+          verboseLog,
         )
       }
       return
@@ -134,7 +158,7 @@ const pluginImpl: FastifyPluginAsync<CorazaFastifyOptions> = async (fastify, opt
       if (interrupted) {
         const it = await tx.interruption()
         if (it) {
-          await emitBlock(it, req, reply, onBlock)
+          await emitBlock(it, req, reply, onBlock, tx, verboseLog)
         }
       }
     } catch (err) {
@@ -147,6 +171,8 @@ const pluginImpl: FastifyPluginAsync<CorazaFastifyOptions> = async (fastify, opt
           req,
           reply,
           onBlock,
+          tx,
+          verboseLog,
         )
       }
     }
@@ -252,11 +278,35 @@ async function emitBlock(
   req: FastifyRequest,
   reply: FastifyReply,
   onBlock: NonNullable<CorazaFastifyOptions['onBlock']>,
+  tx: AnyTx | null,
+  verboseLog: boolean,
 ): Promise<void> {
-  ;(req.log ?? (reply.server as { logger?: unknown }).logger as { warn?: (x: string) => void })?.warn?.(
-    `coraza: request blocked (rule ${interruption.ruleId} status ${interruption.status})`,
+  const log = (req.log ?? (reply.server as { logger?: unknown }).logger as {
+    warn?: (x: string) => void
+  })
+  const dataSuffix = interruption.data ? ` data="${interruption.data}"` : ''
+  log?.warn?.(
+    `coraza: request blocked (rule ${interruption.ruleId} status ${interruption.status})${dataSuffix}`,
   )
-  await onBlock(interruption, req, reply)
+  let matched: MatchedRule[] | undefined
+  if (verboseLog && tx) {
+    try {
+      matched = await tx.matchedRules()
+      for (const r of matched) {
+        log?.warn?.(
+          `coraza: matched (rule ${r.id} severity ${r.severity}) ${r.message}`,
+        )
+      }
+    } catch {
+      // matchedRules read failures must not turn a block into a 500.
+      matched = undefined
+    }
+  }
+  if (matched) {
+    await onBlock(interruption, req, reply, { matchedRules: matched })
+  } else {
+    await onBlock(interruption, req, reply)
+  }
 }
 
 import { headersOf, serializeBody, payloadToBytes } from './helpers.js'

--- a/packages/fastify/test/plugin.test.ts
+++ b/packages/fastify/test/plugin.test.ts
@@ -495,4 +495,39 @@ describe('@coraza/fastify', () => {
     expect((await app.inject({ method: 'GET', url: '/img/logo.png' })).statusCode).toBe(403)
     await app.close()
   })
+
+  // Issue #23 — block log loses signal. The default block log line MUST
+  // include `interruption.data` and verboseLog: true MUST emit one line
+  // per matched rule (so a CRS 949110 anomaly-score block reveals the
+  // contributing 941100/942100 hits, not just the threshold rule).
+  it('issue #23: default block log includes interruption.data and verboseLog emits matched rules', async () => {
+    const { waf } = mockWAF('block', {
+      onHeaders: (tx) => {
+        tx.matchedRules = [
+          { id: 942100, severity: 2, message: 'SQL Injection (libinjection)' },
+          { id: 941100, severity: 2, message: 'XSS reflected' },
+        ]
+        return {
+          ruleId: 949110,
+          action: 'deny',
+          status: 403,
+          data: 'Inbound Anomaly Score Exceeded (Total Score: 10)',
+        }
+      },
+    })
+    const warn = vi.fn()
+    const app = Fastify({ logger: false })
+    // Inject a stub logger on every request so we can capture warn lines.
+    app.addHook('onRequest', async (req) => {
+      ;(req as unknown as { log: { warn: typeof warn } }).log = { warn }
+    })
+    await app.register(coraza, { waf, verboseLog: true })
+    app.get('/x', async () => 'ok')
+    await app.inject({ method: 'GET', url: '/x' })
+    const calls = warn.mock.calls.map((c) => String(c[0]))
+    expect(calls.some((s) => s.includes('request blocked') && s.includes('Inbound Anomaly Score'))).toBe(true)
+    expect(calls.some((s) => s.includes('942100') && s.includes('SQL Injection'))).toBe(true)
+    expect(calls.some((s) => s.includes('941100'))).toBe(true)
+    await app.close()
+  })
 })

--- a/packages/nestjs/src/coraza.guard.ts
+++ b/packages/nestjs/src/coraza.guard.ts
@@ -20,6 +20,7 @@ import type {
   Transaction,
   WorkerTransaction,
   Interruption,
+  MatchedRule,
   SkipOptions,
   IgnoreSpec,
   IgnoreContext,
@@ -28,7 +29,17 @@ import type {
 import { buildIgnoreMatcher, skipToIgnore } from '@coraza/core'
 import { CORAZA_WAF, CORAZA_OPTIONS } from './tokens.js'
 
-type OnBlock = (interruption: Interruption) => HttpException
+/**
+ * Optional context passed as the second argument to a custom `onBlock`.
+ * Only populated when `verboseLog: true`; lets the consumer log every
+ * contributing CRS rule (the `Interruption` only carries the terminating
+ * rule, which for CRS is almost always 949110 / inbound anomaly score).
+ */
+export interface CorazaBlockContext {
+  matchedRules: MatchedRule[]
+}
+
+type OnBlock = (interruption: Interruption, ctx?: CorazaBlockContext) => HttpException
 
 /**
  * Default `onBlock` for `CorazaModule.forRoot`: a 403-ish HttpException
@@ -74,6 +85,7 @@ export class CorazaGuard implements CanActivate {
   private readonly matcher: ((ctx: IgnoreContext) => IgnoreVerdict) | null
   private readonly onWAFError: 'allow' | 'block'
   private readonly onBlock: OnBlock
+  private readonly verboseLog: boolean
 
   constructor(
     @Inject(CORAZA_WAF) private readonly waf: AnyWAF,
@@ -83,11 +95,13 @@ export class CorazaGuard implements CanActivate {
       skip?: SkipOptions | false
       onWAFError?: 'allow' | 'block'
       onBlock?: OnBlock
+      verboseLog?: boolean
     } = {},
   ) {
     this.matcher = resolveIgnoreMatcher(opts.ignore, opts.skip)
     this.onWAFError = opts.onWAFError ?? 'block'
     this.onBlock = opts.onBlock ?? defaultOnBlock
+    this.verboseLog = opts.verboseLog ?? false
   }
 
   async canActivate(ctx: ExecutionContext): Promise<boolean> {
@@ -116,6 +130,7 @@ export class CorazaGuard implements CanActivate {
     ;(req as HttpReq & { _corazaTx?: AnyTx })._corazaTx = tx
 
     let interruption: Interruption | null = null
+    let matched: MatchedRule[] | undefined
     try {
       if (await tx.isRuleEngineOff()) return true
 
@@ -135,7 +150,17 @@ export class CorazaGuard implements CanActivate {
         },
         body,
       )
-      if (interrupted) interruption = await tx.interruption()
+      if (interrupted) {
+        interruption = await tx.interruption()
+        // Pull matched rules BEFORE the finally block closes the tx.
+        if (interruption && this.verboseLog) {
+          try {
+            matched = await tx.matchedRules()
+          } catch {
+            matched = undefined
+          }
+        }
+      }
     } catch (err) {
       this.logger.error(`middleware error: ${(err as Error).message}`)
       if (this.onWAFError === 'block') {
@@ -163,10 +188,20 @@ export class CorazaGuard implements CanActivate {
     }
 
     if (interruption) {
+      const dataSuffix = interruption.data ? ` data="${interruption.data}"` : ''
       this.logger.warn(
-        `blocked request (rule=${interruption.ruleId} action=${interruption.action} status=${interruption.status})`,
+        `blocked request (rule=${interruption.ruleId} action=${interruption.action} status=${interruption.status})${dataSuffix}`,
       )
-      throw this.onBlock(interruption)
+      if (matched) {
+        for (const r of matched) {
+          this.logger.warn(
+            `coraza: matched (rule=${r.id} severity=${r.severity}) ${r.message}`,
+          )
+        }
+      }
+      throw matched
+        ? this.onBlock(interruption, { matchedRules: matched })
+        : this.onBlock(interruption)
     }
     return true
   }

--- a/packages/nestjs/src/coraza.module.ts
+++ b/packages/nestjs/src/coraza.module.ts
@@ -8,7 +8,7 @@ import {
   type IgnoreSpec,
   type Interruption,
 } from '@coraza/core'
-import { CorazaGuard } from './coraza.guard.js'
+import { CorazaGuard, type CorazaBlockContext } from './coraza.guard.js'
 import { CORAZA_OPTIONS, CORAZA_WAF } from './tokens.js'
 
 /**
@@ -50,13 +50,22 @@ interface CorazaNestCommonOptions {
    * Also fires on WAF failure (with a synthesized 503 Interruption) when
    * `onWAFError: 'block'` — check `interruption.source === 'waf-error'`
    * to distinguish a rule hit from a WAF crash.
+   *
+   * The optional `ctx.matchedRules` (only populated when `verboseLog: true`)
+   * lists every rule that matched in the transaction.
    */
-  onBlock?: (interruption: Interruption) => HttpException
+  onBlock?: (interruption: Interruption, ctx?: CorazaBlockContext) => HttpException
   /**
    * What to do if the WAF throws mid-request. Default `'block'` (503).
    * `'allow'` lets the request through; see docs/threat-model.md.
    */
   onWAFError?: 'allow' | 'block'
+  /**
+   * Emit one `logger.warn` per matched rule on a block (ModSecurity
+   * error.log style). Default `false`. The default block log always
+   * includes `interruption.data`.
+   */
+  verboseLog?: boolean
 }
 
 interface CorazaNestBuiltOptions {

--- a/packages/nestjs/test/guard.test.ts
+++ b/packages/nestjs/test/guard.test.ts
@@ -347,4 +347,26 @@ describe('CorazaGuard', () => {
       guard.canActivate(ctx({ method: 'GET', url: '/img/logo.png', headers: {}, socket: {} })),
     ).rejects.toThrow()
   })
+
+  // Issue #23 — block log loses signal. Default block line MUST include
+  // `interruption.data` (free) and verboseLog: true MUST surface every
+  // matching rule and pass them to onBlock(ctx).
+  it('issue #23: passes matchedRules to onBlock when verboseLog is enabled', async () => {
+    const { waf } = mockWAF('block', {
+      onHeaders: (tx) => {
+        tx.matchedRules = [{ id: 942100, severity: 2, message: 'SQLi' }]
+        return { ruleId: 949110, action: 'deny', status: 403, data: 'anomaly' }
+      },
+    })
+    let received: unknown = 'unset'
+    const onBlock = (i: { ruleId: number }, c?: { matchedRules: unknown }): HttpException => {
+      received = c
+      return new HttpException(`blocked ${i.ruleId}`, 403)
+    }
+    const guard = new CorazaGuard(waf, { verboseLog: true, onBlock })
+    await expect(
+      guard.canActivate(ctx({ method: 'GET', url: '/x', headers: {}, socket: {} })),
+    ).rejects.toThrow(HttpException)
+    expect(received).toEqual({ matchedRules: [{ id: 942100, severity: 2, message: 'SQLi' }] })
+  })
 })

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -130,6 +130,39 @@ The legacy `skip:` option is deprecated and mapped to `ignore:` at
 construction (one-shot warning per process). It will be removed at
 stable 0.1.
 
+### Block-log signal: `interruption.data` and verbose matched rules
+
+The default block log line includes `interruption.data` — for CRS this
+is the human-readable reason string (e.g. `Inbound Anomaly Score
+Exceeded (Total Score: 10)`). The terminating rule is almost always
+`949110` (the inbound anomaly threshold), so without this you'd be
+debugging "rule 949110 fired" with no idea which rules contributed.
+
+When you need the contributing rules too, opt in to `verboseLog`:
+
+```ts
+export const proxy = coraza({ waf, verboseLog: true })
+```
+
+That emits one extra `log.warn('coraza: matched', { ruleId, severity, msg })`
+per matched rule (ModSecurity error.log style). The matched-rules array
+is also passed as the optional third argument to a custom `onBlock`:
+
+```ts
+coraza({
+  waf,
+  verboseLog: true,
+  onBlock: (interruption, req, ctx) => {
+    metrics.increment('waf.block', { rule: interruption.ruleId })
+    for (const r of ctx?.matchedRules ?? []) audit.log(r)
+    return new Response('blocked', { status: 403 })
+  },
+})
+```
+
+`verboseLog` adds one `tx.matchedRules()` round-trip per blocked
+request; default is `false`.
+
 ### Body handling
 
 The runner reads the request body via `req.arrayBuffer()` before

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -26,6 +26,7 @@ import type {
   AnyWAF,
   WAFLike,
   Interruption,
+  MatchedRule,
   SkipOptions,
   IgnoreSpec,
   IgnoreContext,
@@ -34,6 +35,19 @@ import type {
 import { buildIgnoreMatcher, skipToIgnore } from '@coraza/core'
 import { NextResponse, type NextRequest } from 'next/server'
 
+/**
+ * Extra context passed as the third argument to `onBlock`. Optional —
+ * legacy `(interruption, req) => Response` handlers still type-check.
+ * Use this to log contributing CRS rules: the `Interruption` itself
+ * only carries the terminating rule, which for CRS is almost always
+ * 949110 (the inbound anomaly score threshold) and that one rule by
+ * itself doesn't tell you what tripped.
+ */
+export interface CorazaBlockContext {
+  /** Every rule that matched in this transaction, in evaluation order. */
+  matchedRules: MatchedRule[]
+}
+
 export interface CorazaNextOptions {
   /**
    * A built WAF or WAFPool. A promise is also accepted so `middleware.ts`
@@ -41,7 +55,11 @@ export interface CorazaNextOptions {
    * construction.
    */
   waf: WAFLike
-  onBlock?: (interruption: Interruption, req: NextRequest) => Response
+  onBlock?: (
+    interruption: Interruption,
+    req: NextRequest,
+    ctx?: CorazaBlockContext,
+  ) => Response
   // No `inspectResponse` on this adapter by design — Next's middleware
   // runs on the request boundary and cannot read the Route Handler's
   // response body. CRS's RESPONSE-* families therefore can't fire on a
@@ -84,6 +102,16 @@ export interface CorazaNextOptions {
    * @default true
    */
   inspectBody?: boolean
+  /**
+   * When `true`, emit one `log.warn('coraza: matched', { ... })` line per
+   * matched rule on a block (ModSecurity error.log style). The default
+   * block log already includes `interruption.data`; this option additionally
+   * surfaces every contributing rule so a 949110 anomaly-score block tells
+   * you which underlying rules pushed the score over the threshold.
+   *
+   * Costs one extra `tx.matchedRules()` round-trip per block; default `false`.
+   */
+  verboseLog?: boolean
 }
 
 /**
@@ -129,6 +157,7 @@ export function createCorazaRunner(
     onBlock = defaultBlock,
     onWAFError = 'block',
     inspectBody = true,
+    verboseLog = false,
   } = options
   const matcher = resolveIgnoreMatcher(options.ignore, options.skip)
 
@@ -190,12 +219,36 @@ export function createCorazaRunner(
       if (interrupted) {
         const interruption = await tx.interruption()
         if (!interruption) return { allow: true }
+        // The WASM has already populated `interruption.data` ("Inbound
+        // Anomaly Score Exceeded (Total Score: N)" for CRS 949110) so
+        // including it in the default log is free. `tx.matchedRules()`
+        // costs an extra read from WASM memory; only pay it when the
+        // consumer opted in via `verboseLog`, or when their `onBlock`
+        // declared a third (`ctx`) parameter.
+        const wantsCtx = onBlock.length >= 3
+        const matchedRules =
+          verboseLog || wantsCtx ? await tx.matchedRules() : undefined
         log.warn('coraza: request blocked', {
           ruleId: interruption.ruleId,
           status: interruption.status,
           action: interruption.action,
+          ...(interruption.data ? { data: interruption.data } : {}),
         })
-        return { blocked: onBlock(interruption, req) }
+        if (verboseLog && matchedRules) {
+          for (const r of matchedRules) {
+            log.warn('coraza: matched', {
+              ruleId: r.id,
+              severity: r.severity,
+              msg: r.message,
+            })
+          }
+        }
+        // Only pass the 3rd arg when populated, so `toHaveBeenCalledWith(it, req)`
+        // assertions in consumer tests don't see a stray `undefined` ctx.
+        const blocked = matchedRules
+          ? onBlock(interruption, req, { matchedRules })
+          : onBlock(interruption, req)
+        return { blocked }
       }
 
       return { allow: true }

--- a/packages/next/test/middleware.test.ts
+++ b/packages/next/test/middleware.test.ts
@@ -362,6 +362,71 @@ describe('@coraza/next', () => {
     await mw(req)
     expect(arrayBufferSpy).toHaveBeenCalled()
   })
+
+  // Issue #23 — block log loses signal. Default block log MUST include
+  // `interruption.data` (free) and verboseLog MUST surface contributing
+  // matched rules so a CRS 949110 / anomaly-score block tells you which
+  // underlying rules pushed the score over the threshold. Without this
+  // the operator-visible line collapses to "949110 / 403 / deny" which
+  // is unactionable.
+  it('issue #23: default block log includes interruption.data and verboseLog emits matched rules', async () => {
+    const { waf } = mockWAF('block', {
+      onHeaders: (tx) => {
+        // Pretend underlying rules contributed to the anomaly score.
+        tx.matchedRules = [
+          { id: 942100, severity: 2, message: 'SQL Injection (libinjection)' },
+          { id: 941100, severity: 2, message: 'XSS reflected' },
+        ]
+        return {
+          ruleId: 949110,
+          action: 'deny',
+          status: 403,
+          data: 'Inbound Anomaly Score Exceeded (Total Score: 10)',
+        }
+      },
+    })
+    const warn = vi.fn()
+    waf.logger = { ...waf.logger, warn }
+    const mw = coraza({ waf, verboseLog: true })
+    await mw(makeReq('https://example.com/x'))
+    // Default block line carries interruption.data (the reason string).
+    expect(warn).toHaveBeenCalledWith(
+      'coraza: request blocked',
+      expect.objectContaining({
+        ruleId: 949110,
+        data: 'Inbound Anomaly Score Exceeded (Total Score: 10)',
+      }),
+    )
+    // verboseLog: true surfaces every contributing rule.
+    expect(warn).toHaveBeenCalledWith(
+      'coraza: matched',
+      expect.objectContaining({ ruleId: 942100, severity: 2, msg: 'SQL Injection (libinjection)' }),
+    )
+    expect(warn).toHaveBeenCalledWith(
+      'coraza: matched',
+      expect.objectContaining({ ruleId: 941100 }),
+    )
+  })
+
+  it('issue #23: matchedRules are passed to onBlock(ctx) when verboseLog is enabled', async () => {
+    const { waf } = mockWAF('block', {
+      onHeaders: (tx) => {
+        tx.matchedRules = [{ id: 942100, severity: 2, message: 'SQLi' }]
+        return { ruleId: 949110, action: 'deny', status: 403, data: 'anomaly' }
+      },
+    })
+    let received: unknown
+    const mw = coraza({
+      waf,
+      verboseLog: true,
+      onBlock: (it, _req, ctx) => {
+        received = ctx
+        return new Response(`blocked ${it.ruleId}`, { status: 403 })
+      },
+    })
+    await mw(makeReq('https://example.com/x'))
+    expect(received).toEqual({ matchedRules: [{ id: 942100, severity: 2, message: 'SQLi' }] })
+  })
 })
 
 // Compose-with-existing-proxy contract. The runner exposes a structured


### PR DESCRIPTION
## Summary

The default block-log line collapsed to `ruleId / status / action`, which for ~all CRS blocks is `949110 / 403 / deny` — the inbound anomaly threshold, with no signal about which rules contributed.

This PR ships, applied to all four adapters (`@coraza/next`, `@coraza/express`, `@coraza/fastify`, `@coraza/nestjs`):

1. **Default block log includes `interruption.data`** — the WASM already populates it (e.g. `Inbound Anomaly Score Exceeded (Total Score: 10)`), surfacing is free.
2. **New `verboseLog?: boolean` option (default `false`)** — when true:
   - Emits one `coraza: matched` log line per contributing rule (ModSecurity `error.log` style).
   - Pulls `tx.matchedRules()` and passes them to a custom `onBlock` via an optional `ctx.matchedRules` argument.

Opting in costs one extra `tx.matchedRules()` round-trip per block.

## What shipped vs. deferred (vs the issue's "Proposed changes")

> 1. Include `interruption.data` in the default block log

✓ Shipped on all four adapters.

> 2. Pass matched rules (or the transaction) to `onBlock`. Either: extend the signature to `onBlock(interruption, req, ctx?: { matchedRules })`, or add a separate `onMatch` hook.

✓ Shipped the first option (`onBlock(interruption, req, ctx?: { matchedRules })`). Did NOT add `onMatch` — easier to add later than to remove. The matched-rules array is also surfaced via the `verboseLog` log lines for consumers who don't want a custom `onBlock`.

> 3. Optionally, add a `verboseLog?: boolean`

✓ Shipped as `verboseLog`.

## Design call

I picked `verboseLog` (boolean) over `auditLog` because the cost is paid on the block path only, and the line format is structured logging (not full audit records). I also gated `tx.matchedRules()` on `verboseLog || onBlock.length >= 3` in `@coraza/next` so consumers who declare a 3-arg `onBlock` get matched rules even without flipping `verboseLog` — no surprise undefined ctx.

## Test plan

- [x] `@coraza/next` — `issue #23: default block log includes interruption.data and verboseLog emits matched rules` (asserts the `coraza: request blocked` line carries `data` and `coraza: matched` is emitted per rule)
- [x] `@coraza/next` — `issue #23: matchedRules are passed to onBlock(ctx) when verboseLog is enabled`
- [x] `@coraza/express`, `@coraza/fastify`, `@coraza/nestjs` — analogous tests
- [x] All pre-existing tests pass (33 express, 36 fastify, 20 nestjs, 24 next)

## Security impact

None. Logging-only change. Block decisions and fail-closed behaviour unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)