### PR TITLE
fix(adapters): #24 preserve multi-value list-form headers

### DIFF
--- a/.changeset/issue-24-headers-multivalue.md
+++ b/.changeset/issue-24-headers-multivalue.md
@@ -1,0 +1,20 @@
+---
+'@coraza/next': patch
+'@coraza/express': patch
+'@coraza/fastify': patch
+'@coraza/nestjs': patch
+---
+
+Preserve multi-value list-form headers when handing requests to Coraza.
+WHATWG `Headers.entries()` joins multi-value headers (`X-Forwarded-For`,
+`Forwarded`, `Via`, `Warning`, `Set-Cookie`) into a single comma-joined
+string, smashing the per-hop boundary that CRS IP-allowlist and
+scanner-detection rules depend on. Each adapter now:
+
+- `@coraza/next` — splits known RFC 7230 list-form request headers on
+  the comma separator and uses `Headers.getSetCookie()` for set-cookie.
+  `Cookie` is NOT split (RFC 6265 uses `;`, not `,`).
+- `@coraza/express`, `@coraza/fastify`, `@coraza/nestjs` — prefer
+  `req.rawHeaders` / `req.raw.rawHeaders` (Node's IncomingMessage flat
+  pair array) when present, falling back to the joined `req.headers`
+  when not. Closes #24.

--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -206,7 +206,7 @@ export function coraza(options: CorazaExpressOptions): RequestHandler {
         method: req.method,
         url: req.originalUrl || req.url,
         protocol: `HTTP/${req.httpVersion}`,
-        headers: headersOf(req.headers),
+        headers: headersOf(req.headers, (req as Request & { rawHeaders?: string[] }).rawHeaders),
         remoteAddr: req.ip ?? '',
         remotePort: req.socket.remotePort ?? 0,
         serverPort: req.socket.localPort ?? 0,
@@ -384,9 +384,27 @@ function emitBlockSync(
 
 function headersOf(
   h: Record<string, string | string[] | undefined>,
+  rawHeaders?: string[],
 ): [string, string][] {
   // Must return a concrete array (not a generator) so the WAFPool path can
   // structured-clone it across the MessagePort.
+  //
+  // Prefer `req.rawHeaders` when available — it preserves multi-value
+  // headers (e.g. two `X-Forwarded-For` lines) as separate entries.
+  // `req.headers` joins those into a single comma-separated string for
+  // most names (Node folds list-form headers per RFC 7230), which loses
+  // the per-hop boundary that CRS IP-allowlist rules and audit logs
+  // care about.
+  if (Array.isArray(rawHeaders) && rawHeaders.length >= 2) {
+    const out: [string, string][] = []
+    for (let i = 0; i + 1 < rawHeaders.length; i += 2) {
+      // rawHeaders preserves original casing; lower-case to match
+      // req.headers convention so downstream Coraza lookups normalise
+      // identically across the two code paths.
+      out.push([rawHeaders[i]!.toLowerCase(), rawHeaders[i + 1]!])
+    }
+    return out
+  }
   const out: [string, string][] = []
   for (const k in h) {
     const v = h[k]

--- a/packages/express/test/middleware.test.ts
+++ b/packages/express/test/middleware.test.ts
@@ -662,4 +662,45 @@ describe('@coraza/express', () => {
       expect.objectContaining({ ruleId: 941100 }),
     )
   })
+
+  // Issue #24 — multi-value list-form headers MUST reach the WAF as
+  // distinct entries, not as a single comma-joined string. Without
+  // `req.rawHeaders` Node folds two `X-Forwarded-For` lines into one
+  // string, hiding the per-hop boundary that CRS IP-allowlist rules
+  // depend on.
+  it('issue #24: multi-value X-Forwarded-For reaches the WAF as separate entries (rawHeaders path)', async () => {
+    const captured: Array<[string, string]> = []
+    const { waf } = mockWAF('block', {
+      onHeaders: (tx) => {
+        captured.push(...tx.headers)
+        return undefined
+      },
+    })
+    const app = express()
+    app.use(coraza({ waf }))
+    app.get('/hi', (_req, res) => res.send('ok'))
+    // supertest sends a single XFF; replace it with two via the raw
+    // socket-level header lines preserved in req.rawHeaders.
+    await request(app)
+      .get('/hi')
+      .set('X-Forwarded-For', '203.0.113.5')
+      .set('X-Forwarded-For', '198.51.100.7')
+    // supertest's .set() overrides duplicates, so simulate the raw
+    // multi-line case by pushing into rawHeaders manually.
+    captured.length = 0
+    const app2 = express()
+    app2.use((req, _res, next) => {
+      ;(req as unknown as { rawHeaders: string[] }).rawHeaders = [
+        'X-Forwarded-For', '203.0.113.5',
+        'X-Forwarded-For', '198.51.100.7',
+        'Host', 'localhost',
+      ]
+      next()
+    })
+    app2.use(coraza({ waf }))
+    app2.get('/hi', (_req, res) => res.send('ok'))
+    await request(app2).get('/hi')
+    const xff = captured.filter(([k]) => k === 'x-forwarded-for').map(([, v]) => v)
+    expect(xff).toEqual(['203.0.113.5', '198.51.100.7'])
+  })
 })

--- a/packages/fastify/src/helpers.ts
+++ b/packages/fastify/src/helpers.ts
@@ -6,7 +6,21 @@ const encoder = new TextEncoder()
 
 export function headersOf(
   h: Record<string, string | string[] | number | undefined>,
+  rawHeaders?: string[],
 ): [string, string][] {
+  // Prefer `req.raw.rawHeaders` when available — it preserves
+  // multi-value headers (two X-Forwarded-For lines, multiple Set-Cookie
+  // entries, etc.) as distinct pairs. `req.headers` is the WHATWG-style
+  // merged form that joins list-headers into one comma-separated
+  // string, losing per-hop boundaries that CRS rules and audit logs
+  // depend on.
+  if (Array.isArray(rawHeaders) && rawHeaders.length >= 2) {
+    const out: [string, string][] = []
+    for (let i = 0; i + 1 < rawHeaders.length; i += 2) {
+      out.push([rawHeaders[i]!.toLowerCase(), rawHeaders[i + 1]!])
+    }
+    return out
+  }
   const out: [string, string][] = []
   for (const [k, v] of Object.entries(h)) {
     if (v === undefined) continue

--- a/packages/fastify/src/index.ts
+++ b/packages/fastify/src/index.ts
@@ -148,7 +148,7 @@ const pluginImpl: FastifyPluginAsync<CorazaFastifyOptions> = async (fastify, opt
           method: req.method,
           url: req.url,
           protocol: `HTTP/${req.raw.httpVersion ?? '1.1'}`,
-          headers: headersOf(req.headers),
+          headers: headersOf(req.headers, req.raw?.rawHeaders),
           remoteAddr: req.ip,
           remotePort: req.socket.remotePort ?? 0,
           serverPort: req.socket.localPort ?? 0,

--- a/packages/fastify/test/plugin.test.ts
+++ b/packages/fastify/test/plugin.test.ts
@@ -530,4 +530,35 @@ describe('@coraza/fastify', () => {
     expect(calls.some((s) => s.includes('941100'))).toBe(true)
     await app.close()
   })
+
+  // Issue #24 — multi-value list-form headers MUST reach the WAF as
+  // separate entries. The fix uses `req.raw.rawHeaders` (Node's
+  // IncomingMessage rawHeaders array) instead of the
+  // already-comma-joined `req.headers`.
+  it('issue #24: multi-value X-Forwarded-For reaches the WAF as separate entries', async () => {
+    const captured: Array<[string, string]> = []
+    const { waf } = mockWAF('block', {
+      onHeaders: (tx) => {
+        captured.push(...tx.headers)
+        return undefined
+      },
+    })
+    const app = Fastify({ logger: false })
+    // Inject simulated multi-value rawHeaders via an onRequest hook so
+    // we don't depend on the test framework supporting duplicate
+    // headers (most don't).
+    app.addHook('onRequest', async (req) => {
+      ;(req.raw as unknown as { rawHeaders: string[] }).rawHeaders = [
+        'Host', 'localhost',
+        'X-Forwarded-For', '203.0.113.5',
+        'X-Forwarded-For', '198.51.100.7',
+      ]
+    })
+    await app.register(coraza, { waf })
+    app.get('/hi', async () => 'ok')
+    await app.inject({ method: 'GET', url: '/hi' })
+    const xff = captured.filter(([k]) => k === 'x-forwarded-for').map(([, v]) => v)
+    expect(xff).toEqual(['203.0.113.5', '198.51.100.7'])
+    await app.close()
+  })
 })

--- a/packages/nestjs/src/coraza.guard.ts
+++ b/packages/nestjs/src/coraza.guard.ts
@@ -70,10 +70,18 @@ interface HttpReq {
   originalUrl?: string
   httpVersion?: string
   headers: Record<string, string | string[] | undefined>
+  /**
+   * Node IncomingMessage.rawHeaders — flat [name, value, name, value, …]
+   * preserving original casing and multi-value pairs. We prefer this
+   * over `headers` because Node folds list-form headers (X-Forwarded-For
+   * etc.) into a comma-joined string at the IncomingMessage layer,
+   * losing per-hop boundaries.
+   */
+  rawHeaders?: string[]
   body?: unknown
   ip?: string
   socket?: { remotePort?: number; localPort?: number }
-  raw?: { httpVersion?: string }
+  raw?: { httpVersion?: string; rawHeaders?: string[] }
 }
 
 const encoder = new TextEncoder()
@@ -143,7 +151,7 @@ export class CorazaGuard implements CanActivate {
           method: req.method,
           url: req.originalUrl || req.url || '/',
           protocol: `HTTP/${req.httpVersion ?? req.raw?.httpVersion ?? '1.1'}`,
-          headers: headersOf(req.headers),
+          headers: headersOf(req.headers, req.rawHeaders ?? req.raw?.rawHeaders),
           remoteAddr: req.ip ?? '',
           remotePort: req.socket?.remotePort ?? 0,
           serverPort: req.socket?.localPort ?? 0,
@@ -209,7 +217,19 @@ export class CorazaGuard implements CanActivate {
 
 function headersOf(
   h: Record<string, string | string[] | undefined>,
+  rawHeaders?: string[],
 ): [string, string][] {
+  // Prefer `req.rawHeaders` (Express) / `req.raw.rawHeaders` (Fastify)
+  // when available — it preserves multi-value headers as distinct
+  // entries, where `req.headers` would join them into a single
+  // comma-separated string and lose the per-hop boundary.
+  if (Array.isArray(rawHeaders) && rawHeaders.length >= 2) {
+    const out: [string, string][] = []
+    for (let i = 0; i + 1 < rawHeaders.length; i += 2) {
+      out.push([rawHeaders[i]!.toLowerCase(), rawHeaders[i + 1]!])
+    }
+    return out
+  }
   const out: [string, string][] = []
   for (const [k, v] of Object.entries(h)) {
     if (v === undefined) continue

--- a/packages/nestjs/test/guard.test.ts
+++ b/packages/nestjs/test/guard.test.ts
@@ -369,4 +369,35 @@ describe('CorazaGuard', () => {
     ).rejects.toThrow(HttpException)
     expect(received).toEqual({ matchedRules: [{ id: 942100, severity: 2, message: 'SQLi' }] })
   })
+
+  // Issue #24 — multi-value list-form headers MUST reach the WAF as
+  // separate entries. NestJS bridges to either Express or Fastify;
+  // both expose Node's IncomingMessage with `rawHeaders` (Express:
+  // `req.rawHeaders`; Fastify: `req.raw.rawHeaders`). We prefer
+  // either over the comma-joined `req.headers`.
+  it('issue #24: multi-value X-Forwarded-For reaches the WAF as separate entries', async () => {
+    const captured: Array<[string, string]> = []
+    const { waf } = mockWAF('block', {
+      onHeaders: (tx) => {
+        captured.push(...tx.headers)
+        return undefined
+      },
+    })
+    const guard = new CorazaGuard(waf)
+    await guard.canActivate(
+      ctx({
+        method: 'GET',
+        url: '/',
+        headers: { host: 'localhost' },
+        rawHeaders: [
+          'Host', 'localhost',
+          'X-Forwarded-For', '203.0.113.5',
+          'X-Forwarded-For', '198.51.100.7',
+        ],
+        socket: {},
+      }),
+    )
+    const xff = captured.filter(([k]) => k === 'x-forwarded-for').map(([, v]) => v)
+    expect(xff).toEqual(['203.0.113.5', '198.51.100.7'])
+  })
 })

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -163,6 +163,26 @@ coraza({
 `verboseLog` adds one `tx.matchedRules()` round-trip per blocked
 request; default is `false`.
 
+### Multi-value request headers
+
+Coraza receives every value of a multi-value header as a separate
+`[name, value]` entry, not the WHATWG-`Headers`-joined `"v1, v2"`
+string. This matters most for IP-aware list-form headers:
+
+- `Set-Cookie` — split via `Headers.getSetCookie()` (response side).
+- `X-Forwarded-For`, `Forwarded`, `Via`, `Warning` — split on the RFC
+  7230 list separator (`,` plus optional whitespace) so each per-hop
+  token reaches the WAF as its own value. CRS IP-allowlist and
+  scanner-detection rules need this to evaluate the original client
+  hop, not a smashed string.
+
+`Cookie` is intentionally NOT split: by RFC 6265, multiple cookies in
+a single header are separated by `; ` (not `,`), and commas can appear
+inside cookie values. If a proxy in front of you sends multiple
+`Cookie` *header lines* (spec-violating but it happens), they reach
+the WAF as the WHATWG-joined string. If that's a hot path for you,
+pre-process `req.headers` before handing it to Coraza.
+
 ### Body handling
 
 The runner reads the request body via `req.arrayBuffer()` before

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -305,9 +305,48 @@ export function defaultBlock(interruption: Interruption, _req: NextRequest): Res
   )
 }
 
+// RFC 7230 §3.2.2 list-form headers — multiple values delivered as
+// separate header lines are equivalent to a single line with values
+// joined by ", ". `Headers.entries()` only ever produces the joined
+// form, but Coraza's tokenizers (and CRS variables like
+// REQUEST_HEADERS:X-Forwarded-For) work better when each value is
+// delivered as its own [name, value] entry — e.g. for IP-allowlist
+// checks against the original client hop. We split the joined string
+// on `, ` so each token reaches the WAF as its own header value.
+//
+// `cookie` is intentionally NOT in this set: by RFC 6265 multiple cookies
+// inside a single Cookie header are separated by "; ", not ", ", and
+// commas can legitimately appear inside cookie values. Splitting on ","
+// would corrupt the cookie. Multiple Cookie *header lines* are
+// spec-violating; leave them as the WHATWG-joined string.
+const RFC7230_LIST_HEADERS = new Set([
+  'x-forwarded-for',
+  'forwarded',
+  'via',
+  'warning',
+])
+
 function headersOf(h: Headers): [string, string][] {
   const out: [string, string][] = []
-  for (const [k, v] of h.entries()) out.push([k, v])
+  // Preserve every individual Set-Cookie via the spec-blessed accessor.
+  // Most relevant on the response path (not implemented in this adapter
+  // yet) but safe to include for symmetry — `getSetCookie()` returns []
+  // when no Set-Cookie header is present.
+  for (const c of h.getSetCookie()) out.push(['set-cookie', c])
+  for (const [k, v] of h.entries()) {
+    if (k === 'set-cookie') continue // already emitted via getSetCookie()
+    if (RFC7230_LIST_HEADERS.has(k) && v.includes(',')) {
+      // Split on RFC 7230 list separator (`,` with optional whitespace).
+      // Preserves the relative order of values; each non-empty token
+      // becomes its own [k, v] pair so two `X-Forwarded-For` header
+      // lines reach the WAF as two distinct values, not "v1, v2".
+      for (const tok of v.split(/\s*,\s*/)) {
+        if (tok.length > 0) out.push([k, tok])
+      }
+      continue
+    }
+    out.push([k, v])
+  }
   return out
 }
 

--- a/packages/next/test/middleware.test.ts
+++ b/packages/next/test/middleware.test.ts
@@ -427,6 +427,44 @@ describe('@coraza/next', () => {
     await mw(makeReq('https://example.com/x'))
     expect(received).toEqual({ matchedRules: [{ id: 942100, severity: 2, message: 'SQLi' }] })
   })
+
+  // Issue #24 — multi-value list-form headers MUST reach the WAF as
+  // distinct entries, not as a single comma-joined string. This is most
+  // visible on `x-forwarded-for` where every CRS IP-allowlist or
+  // scanner-detection rule that splits on hop boundaries silently
+  // misfires when the per-hop addresses are smashed into one token.
+  it('issue #24: multi-value X-Forwarded-For reaches the WAF as separate header entries', async () => {
+    const { waf, state } = mockWAF('block')
+    const mw = coraza({ waf })
+    // Build a Headers object with two X-Forwarded-For entries — the
+    // Headers.append() path is the only way to construct distinct
+    // values for the same name (the constructor would dedupe).
+    const headers = new Headers()
+    headers.append('x-forwarded-for', '203.0.113.5')
+    headers.append('x-forwarded-for', '198.51.100.7')
+    const req = new NextRequest(new Request('https://example.com/', { headers }))
+    await mw(req)
+    // The bundle decoder writes captured headers to tx.headers; assert
+    // both XFF values are there as separate entries.
+    expect(state.nextTx).toBeGreaterThanOrEqual(1)
+    // The transaction was already destroyed when the bundle finished;
+    // capture state on the next-to-last tx by intercepting onHeaders
+    // instead. Re-run with a stub to inspect.
+    const captured: Array<[string, string]> = []
+    const { waf: waf2 } = mockWAF('block', {
+      onHeaders: (tx) => {
+        captured.push(...tx.headers)
+        return undefined
+      },
+    })
+    const mw2 = coraza({ waf: waf2 })
+    const headers2 = new Headers()
+    headers2.append('x-forwarded-for', '203.0.113.5')
+    headers2.append('x-forwarded-for', '198.51.100.7')
+    await mw2(new NextRequest(new Request('https://example.com/', { headers: headers2 })))
+    const xff = captured.filter(([k]) => k === 'x-forwarded-for').map(([, v]) => v)
+    expect(xff).toEqual(['203.0.113.5', '198.51.100.7'])
+  })
 })
 
 // Compose-with-existing-proxy contract. The runner exposes a structured


### PR DESCRIPTION
## Summary

Both `Headers.entries()` (WHATWG) and Node's `req.headers` collapse multi-value list-form headers into a single comma-separated string. This silently breaks every CRS rule that expects per-hop or per-cookie evaluation:

- `X-Forwarded-For`, `Forwarded`, `Via`, `Warning` — IP-allowlist and scanner-detection rules see one smashed token, not the per-hop chain.
- `Set-Cookie` (response side) — CRS cookie rules misfire when two cookies become `name1=v1, name2=v2`.

## Suggestions (from issue) and what shipped

> 1. Use raw header arrays where the runtime exposes them. Node ≥ 18 has `Headers.getSetCookie()`; Fastify, Express, and undici expose raw header arrays via `req.rawHeaders` / `req.headersDistinct`.

✓ Shipped:
- `@coraza/next` — uses `Headers.getSetCookie()` for set-cookie; splits `x-forwarded-for`, `forwarded`, `via`, `warning` on RFC 7230 `,` separator.
- `@coraza/express`, `@coraza/fastify`, `@coraza/nestjs` — prefer `req.rawHeaders` / `req.raw.rawHeaders` (Node's IncomingMessage flat-pair array). Each entry comes through with original casing → lower-cased.

> 2. Document the limitation.

✓ Updated `packages/next/README.md` "Multi-value request headers" section.

> 3. At the adapter level, special-case `set-cookie` when iterating responses.

Deferred — `@coraza/next` doesn't yet implement response-side inspection. The `getSetCookie()` call is in the request-side helper for symmetry; it's a no-op for incoming requests.

## Design call

I picked **per-header allowlist + raw-header preference** over a blanket "split everything on `,`" because `Cookie` legitimately uses `,` inside cookie values (RFC 6265 separator is `;`). Splitting Cookie on `,` would corrupt cookies. The README notes this explicitly.

The Express/Fastify/NestJS code chose `rawHeaders` over `headersDistinct` because `rawHeaders` is universally available on Node's IncomingMessage; `headersDistinct` is a newer addition not consistently present across runtimes.

## Test plan

- [x] `@coraza/next` — `issue #24: multi-value X-Forwarded-For reaches the WAF as separate header entries`
- [x] `@coraza/express`, `@coraza/fastify`, `@coraza/nestjs` — analogous tests using `req.rawHeaders` / `req.raw.rawHeaders`
- [x] All pre-existing tests pass

## Security impact

**Improves detection.** Multiple X-Forwarded-For lines now reach Coraza as separate per-hop addresses, restoring CRS IP rule effectiveness. No bypass surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)