### PR TITLE
fix(next): #26 add inspectBody option and document body handling

### DIFF
--- a/.changeset/issue-26-inspect-body.md
+++ b/.changeset/issue-26-inspect-body.md
@@ -1,0 +1,11 @@
+---
+'@coraza/next': patch
+---
+
+Add `inspectBody?: boolean` (default `true`) on `@coraza/next`. When
+`false`, the runner skips `req.arrayBuffer()` entirely — the request
+body reaches the route handler untouched, body-targeted CRS rules
+(`ARGS_POST`, `REQUEST_BODY`) cannot fire, but URL/header/cookie rules
+and the phase-2 anomaly evaluator still run. Documented as a security
+trade-off in the README "Body handling" section, alongside the
+runtime-version compatibility notes for body re-injection. Closes #26.

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -130,6 +130,35 @@ The legacy `skip:` option is deprecated and mapped to `ignore:` at
 construction (one-shot warning per process). It will be removed at
 stable 0.1.
 
+### Body handling
+
+The runner reads the request body via `req.arrayBuffer()` before
+forwarding to your route handler. On Next 16 (`proxy.ts`) the runtime
+buffers the request and the route handler can still call `req.json()`
+or `req.formData()` against its own copy. We test against Next 16.x;
+older versions or runtimes that don't re-inject the body MAY break
+downstream parsers — symptom is `Unexpected end of JSON input` from
+your route handler with no Coraza log line.
+
+If body re-injection isn't reliable on your runtime, OR you want
+WAF on headers/URL only (a common false-positive reduction), opt out:
+
+```ts
+export const proxy = coraza({ waf, inspectBody: false })
+```
+
+`inspectBody: false`:
+- Skips `req.arrayBuffer()` entirely; body reaches your route handler
+  untouched.
+- Disables body-targeted CRS rules (`ARGS_POST`, `REQUEST_BODY`) —
+  most XSS and many SQLi attacks won't be detected.
+- Still runs URL + header + cookie rules and the phase-2 anomaly
+  evaluator on every request.
+
+Default is `inspectBody: true`. **Flipping it off is a security
+trade-off** — body-bearing attacks become invisible. Document why
+you're doing it in your codebase.
+
 ### Limitation — no response-body inspection
 
 Next middleware / proxy runs on the request boundary. Route Handlers own

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -60,6 +60,30 @@ export interface CorazaNextOptions {
    * knob; see docs/threat-model.md before flipping it.
    */
   onWAFError?: 'allow' | 'block'
+  /**
+   * Whether to read the request body and feed it to Coraza. Default `true`.
+   *
+   * When `false`, the runner skips `req.arrayBuffer()` entirely — the
+   * body is left untouched on the way to your route handler, and CRS's
+   * body-targeted rules (SQLi/XSS/RCE that match `ARGS_POST`/`REQUEST_BODY`)
+   * cannot fire. URL/header/cookie rules still evaluate normally, and
+   * the bundle still triggers phase 2 (anomaly score, etc.) on
+   * non-body inputs.
+   *
+   * Why you might flip it off:
+   *   - You're on a Next runtime that doesn't re-inject the body
+   *     reliably to the route handler after the proxy reads it.
+   *   - Body inspection is your dominant source of CRS false positives
+   *     and you'd rather defend with header/URL rules only.
+   *   - You're streaming large uploads that you don't want buffered
+   *     into Coraza memory.
+   *
+   * Security trade-off: significant. Body-targeted attacks (most XSS,
+   * many SQLi) won't be detected. Document why you flipped it.
+   *
+   * @default true
+   */
+  inspectBody?: boolean
 }
 
 /**
@@ -100,7 +124,12 @@ export type CorazaDecision = { blocked: Response } | { allow: true }
 export function createCorazaRunner(
   options: CorazaNextOptions,
 ): (req: NextRequest) => Promise<CorazaDecision> {
-  const { waf: wafOrPromise, onBlock = defaultBlock, onWAFError = 'block' } = options
+  const {
+    waf: wafOrPromise,
+    onBlock = defaultBlock,
+    onWAFError = 'block',
+    inspectBody = true,
+  } = options
   const matcher = resolveIgnoreMatcher(options.ignore, options.skip)
 
   let wafRef: AnyWAF | null = null
@@ -137,11 +166,12 @@ export function createCorazaRunner(
     try {
       if (await tx.isRuleEngineOff()) return { allow: true }
 
-      // Read the body up front (Next streams it); the bundle needs it
-      // to guarantee phase 2 runs. `'skip-body'` short-circuits the body
-      // read entirely so we don't pay to materialize an oversized payload.
+      // to guarantee phase 2 runs. Skip the read when:
+      //   - the ignore: spec said `'skip-body'` (large-upload bypass), OR
+      //   - the consumer set `inspectBody: false` (body-targeted rules
+      //     disabled by config).
       const body =
-        verdict === 'skip-body'
+        verdict === 'skip-body' || !inspectBody
           ? undefined
           : hasBody(req)
             ? new Uint8Array(await req.arrayBuffer())

--- a/packages/next/test/middleware.test.ts
+++ b/packages/next/test/middleware.test.ts
@@ -311,6 +311,57 @@ describe('@coraza/next', () => {
     const png = await mw(makeReq('https://example.com/img/logo.png'))
     expect(png.status).toBe(403)
   })
+
+  // Issue #26 — request body consumption is undocumented and adapter-fragile.
+  // `inspectBody: false` lets users opt out of body inspection — the
+  // body is left untouched, the runner skips `req.arrayBuffer()`
+  // entirely, and body-targeted CRS rules see an empty body. URL +
+  // header rules and the phase-2 anomaly evaluator still run.
+  it('issue #26: inspectBody: false leaves the request body untouched', async () => {
+    const { waf, state } = mockWAF('block')
+    const mw = coraza({ waf, inspectBody: false })
+    const payload = JSON.stringify({ msg: '<script>alert(1)</script>' })
+    const req = makeReq('https://example.com/', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: payload,
+    })
+    const arrayBufferSpy = vi.spyOn(req, 'arrayBuffer')
+    await mw(req)
+    expect(arrayBufferSpy).not.toHaveBeenCalled()
+    expect(state.nextTx).toBe(1)
+  })
+
+  it('issue #26: inspectBody: false still allows header/URL rules to fire', async () => {
+    const { waf } = mockWAF('block', {
+      onHeaders: (tx) =>
+        tx.uri?.uri?.includes('attack')
+          ? { ruleId: 942100, action: 'deny', status: 403, data: 'SQLi-in-URL' }
+          : undefined,
+    })
+    const mw = coraza({ waf, inspectBody: false })
+    const res = await mw(
+      makeReq('https://example.com/?q=attack', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ harmless: true }),
+      }),
+    )
+    expect(res.status).toBe(403)
+  })
+
+  it('issue #26: default (inspectBody not set) still reads the body', async () => {
+    const { waf } = mockWAF('block')
+    const mw = coraza({ waf })
+    const req = makeReq('https://example.com/', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ msg: '<script>' }),
+    })
+    const arrayBufferSpy = vi.spyOn(req, 'arrayBuffer')
+    await mw(req)
+    expect(arrayBufferSpy).toHaveBeenCalled()
+  })
 })
 
 // Compose-with-existing-proxy contract. The runner exposes a structured


### PR DESCRIPTION
## Summary

`createCorazaRunner` calls `req.arrayBuffer()` unconditionally on every body-bearing request. On Next 16's `proxy.ts` this works because the runtime buffers the request and re-injects it to the route handler — but that behaviour isn't documented anywhere and isn't part of any contract. If Next switches to streaming for large bodies, every POST/PUT/PATCH downstream silently breaks (`Unexpected end of JSON input`) with no Coraza log line pointing at the cause.

## Suggestions (from issue) and what shipped

> 1. Document the assumption.

✓ New "Body handling" section in `packages/next/README.md` — states explicitly that the runner consumes `req.arrayBuffer()`, lists tested Next versions (16.x), calls out streaming-body / large-payload caveats.

> 2. Provide a body-skip option. A flag like `inspectBody?: boolean` (default `true`) that skips the `arrayBuffer()` call entirely.

✓ Shipped exactly as the issue described: `inspectBody?: boolean` option, default `true`. When `false`, `req.arrayBuffer()` is never called; body-targeted CRS rules can't fire; URL/header/cookie rules and the phase-2 anomaly evaluator still run.

> 3. Optional: clone before consuming. `req.clone().arrayBuffer()`.

Deferred. `clone()` allocates a second copy of every request body — a measurable per-request cost we don't want on the default path. The `inspectBody: false` opt-out covers the user's actual concern (downstream parsers breaking) without the universal overhead. If a future Next runtime change forces clone, we can revisit.

## Scope: Next-only

Per the task constraints, `inspectBody` is `@coraza/next`-specific because the issue references `NextRequest.arrayBuffer()` semantics. The other adapters already have their own body handling (Express's body-parser runs first, Fastify reads via its parser, NestJS bridges to one of the two) and don't have the same re-injection question.

## Security trade-off

`inspectBody: false` is **opt-in** and makes body-targeted attacks (most XSS, many SQLi) invisible to the WAF. The README explicitly calls this out and asks consumers to document why they're flipping it. Default behaviour is unchanged — body inspection on, all rules fire.

## Test plan

- [x] `@coraza/next` — `issue #26: inspectBody: false leaves the request body untouched` (asserts `req.arrayBuffer()` is never called)
- [x] `@coraza/next` — `issue #26: inspectBody: false still allows header/URL rules to fire` (URL-targeted SQLi still triggers a 403)
- [x] `@coraza/next` — `issue #26: default (inspectBody not set) still reads the body` (regression guard for the default path)
- [x] All pre-existing tests pass (25 next tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)