### PR TITLE
fix(next): #27 make client IP extraction pluggable via extractClientIp

### DIFF
--- a/.changeset/issue-27-extract-client-ip.md
+++ b/.changeset/issue-27-extract-client-ip.md
@@ -1,0 +1,12 @@
+---
+'@coraza/next': patch
+---
+
+Add `extractClientIp?: (req: NextRequest) => string` on `@coraza/next`.
+The previous behaviour — first hop of `X-Forwarded-For` — is the new
+default (no regression), exposed as `defaultExtractClientIp`. Override
+it to support Cloudflare (`cf-connecting-ip`), AWS ALB / Nginx default
+(last hop of XFF), or direct-exposure topologies. Without correct IP
+extraction, CRS IP-based rules (REQUEST-913, IP allowlist/blocklist)
+are advisory at best — README "Client IP extraction" section spells
+this out for each common topology. Closes #27.

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -192,6 +192,36 @@ Default is `inspectBody: true`. **Flipping it off is a security
 trade-off** — body-bearing attacks become invisible. Document why
 you're doing it in your codebase.
 
+### Client IP extraction (`extractClientIp`)
+
+The default takes the first hop of `X-Forwarded-For`. That's correct
+ONLY when there's a single trusted proxy in front of the app and that
+proxy prepends the real client IP. It's wrong on every other topology:
+
+| Topology | Header / source | Pattern |
+| --- | --- | --- |
+| Cloudflare | `cf-connecting-ip` | `req.headers.get('cf-connecting-ip')` |
+| AWS ALB / Nginx default | last-hop of XFF | `xff.split(',').pop()?.trim()` |
+| Vercel (no Cloudflare) | first-hop of XFF | default works |
+| Direct exposure | none | `''` (CRS IP rules go advisory) |
+
+Pass `extractClientIp` to override:
+
+```ts
+export const proxy = coraza({
+  waf,
+  extractClientIp: (req) =>
+    req.headers.get('cf-connecting-ip') ??
+    req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
+    '',
+})
+```
+
+The function MUST return a string. Return `''` if no IP can be
+determined; CRS IP-based rules (REQUEST-913 scanner detection,
+allowlist/blocklist) will then no-op without firing false positives.
+**Without correct IP extraction, IP-based rules are advisory at best.**
+
 ### Limitation — no response-body inspection
 
 Next middleware / proxy runs on the request boundary. Route Handlers own

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -112,6 +112,37 @@ export interface CorazaNextOptions {
    * Costs one extra `tx.matchedRules()` round-trip per block; default `false`.
    */
   verboseLog?: boolean
+  /**
+   * Override how the client IP is extracted from the incoming request.
+   *
+   * Default: first hop of `X-Forwarded-For` (e.g. `203.0.113.5` from
+   * `203.0.113.5, 10.0.0.1`). This is correct ONLY when there is a
+   * single trusted proxy in front of the app and that proxy prepends
+   * the real client IP. It's wrong on:
+   *
+   *   - **Cloudflare**: use `req.headers.get('cf-connecting-ip')`.
+   *   - **AWS ALB / Nginx default**: append-at-end → take the last
+   *     non-internal hop.
+   *   - **Direct exposure**: there is no `X-Forwarded-For`; rely on
+   *     the socket address (not exposed by `NextRequest`).
+   *
+   * The function MUST return a string. Return `''` if no IP can be
+   * determined; CRS IP-based rules will then no-op (advisory mode).
+   *
+   * Example:
+   * ```ts
+   * coraza({
+   *   waf,
+   *   extractClientIp: (req) =>
+   *     req.headers.get('cf-connecting-ip') ??
+   *     req.headers.get('x-forwarded-for')?.split(',').pop()?.trim() ?? '',
+   * })
+   * ```
+   *
+   * Without correct IP extraction, IP-based rules (REQUEST-913
+   * scanner detection, allowlist/blocklist) are advisory at best.
+   */
+  extractClientIp?: (req: NextRequest) => string
 }
 
 /**
@@ -158,6 +189,7 @@ export function createCorazaRunner(
     onWAFError = 'block',
     inspectBody = true,
     verboseLog = false,
+    extractClientIp = defaultExtractClientIp,
   } = options
   const matcher = resolveIgnoreMatcher(options.ignore, options.skip)
 
@@ -212,7 +244,7 @@ export function createCorazaRunner(
           url: url.pathname + url.search,
           protocol: 'HTTP/1.1',
           headers: headersOf(req.headers),
-          remoteAddr: req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? '',
+          remoteAddr: extractClientIp(req),
         },
         body,
       )
@@ -309,6 +341,16 @@ function headersOf(h: Headers): [string, string][] {
   const out: [string, string][] = []
   for (const [k, v] of h.entries()) out.push([k, v])
   return out
+}
+
+/**
+ * Default client-IP extractor: first hop of `X-Forwarded-For`. Same
+ * behaviour as before this option existed; correct only when a single
+ * trusted proxy in front of the app prepends the real client IP. See
+ * `CorazaNextOptions.extractClientIp` for proxy-topology overrides.
+ */
+export function defaultExtractClientIp(req: NextRequest): string {
+  return req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? ''
 }
 
 function hasBody(req: NextRequest): boolean {

--- a/packages/next/test/middleware.test.ts
+++ b/packages/next/test/middleware.test.ts
@@ -427,6 +427,65 @@ describe('@coraza/next', () => {
     await mw(makeReq('https://example.com/x'))
     expect(received).toEqual({ matchedRules: [{ id: 942100, severity: 2, message: 'SQLi' }] })
   })
+
+  // Issue #27 — remoteAddr extraction was hard-coded to first XFF hop.
+  // The new `extractClientIp` option is a function the consumer
+  // controls; whatever it returns is what reaches the WAF as
+  // `remoteAddr`. Lets users adapt to Cloudflare / ALB / Nginx /
+  // direct-exposure topologies without dropping createCorazaRunner.
+  it('issue #27: extractClientIp lets the consumer pick the IP source', async () => {
+    let observed = ''
+    const { waf } = mockWAF('block', {
+      onHeaders: (tx) => {
+        observed = tx.conn?.addr ?? ''
+        return undefined
+      },
+    })
+    const mw = coraza({
+      waf,
+      extractClientIp: (req) => req.headers.get('cf-connecting-ip') ?? '',
+    })
+    await mw(
+      makeReq('https://example.com/', {
+        headers: {
+          'cf-connecting-ip': '203.0.113.99',
+          // Even with XFF set, the custom extractor wins.
+          'x-forwarded-for': '10.0.0.1, 10.0.0.2',
+        },
+      }),
+    )
+    expect(observed).toBe('203.0.113.99')
+  })
+
+  it('issue #27: default extractor still uses first XFF hop (no regression)', async () => {
+    let observed = ''
+    const { waf } = mockWAF('block', {
+      onHeaders: (tx) => {
+        observed = tx.conn?.addr ?? ''
+        return undefined
+      },
+    })
+    const mw = coraza({ waf })
+    await mw(
+      makeReq('https://example.com/', {
+        headers: { 'x-forwarded-for': '203.0.113.5, 10.0.0.1' },
+      }),
+    )
+    expect(observed).toBe('203.0.113.5')
+  })
+
+  it('issue #27: extractClientIp can return "" (no IP) and CRS IP rules become advisory', async () => {
+    let observed: string | undefined
+    const { waf } = mockWAF('block', {
+      onHeaders: (tx) => {
+        observed = tx.conn?.addr
+        return undefined
+      },
+    })
+    const mw = coraza({ waf, extractClientIp: () => '' })
+    await mw(makeReq('https://example.com/'))
+    expect(observed).toBe('')
+  })
 })
 
 // Compose-with-existing-proxy contract. The runner exposes a structured


### PR DESCRIPTION
## Summary

`@coraza/next` derived the WAF transaction's `remoteAddr` with a hard-coded `req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? ''`. That's correct ONLY behind a single trusted proxy that prepends the real client IP. Behind Cloudflare, AWS ALB, Nginx default, or with no proxy, the value is wrong or empty — and CRS IP-based rules (REQUEST-913 scanner detection, IP allowlist/blocklist) silently misfire. Consumers couldn't fix it without dropping `createCorazaRunner` and reimplementing the whole transaction lifecycle.

## Suggestions (from issue) and what shipped

> 1. Make IP extraction pluggable. Add an option `extractClientIp?: (req: NextRequest) => string`.

✓ Shipped exactly as specified. Default (`defaultExtractClientIp`, also exported) keeps the previous first-hop XFF behaviour — zero regression for existing deployments.

> 2. Or: a `trustProxyDepth: number` shorthand.

Deferred — picked the function form because it covers every topology in one knob:
- Cloudflare needs `cf-connecting-ip` fallback (a number alone can't express that).
- "Last hop of XFF after stripping internal hops" needs a CIDR-aware policy that doesn't belong in this adapter.
- A function lets the consumer compose both: `cf-connecting-ip ?? lastHopOfXff(...)`.

If a future user really wants the depth shorthand we can add it on top of the function — easier to layer than to remove.

> 3. Document the security implication.

✓ New "Client IP extraction" section in `packages/next/README.md`, with a per-topology table and the explicit "Without correct IP extraction, IP-based rules are advisory at best" call-out.

## Scope: Next-only

`extractClientIp(req: NextRequest)` references `NextRequest`-shaped APIs. The other adapters already have framework-native equivalents (`req.ip` on Express/Fastify with proxy-trust config in those frameworks; NestJS bridges to one of them) and don't have the same gap.

## Design call

I picked `extractClientIp(req): string` over `extractClientIp(req): string | undefined` because:
- A `string` return matches the existing `remoteAddr: string` field on `RequestInfo`.
- The "no IP known" sentinel is `''` — explicit, no nullable plumbing in the adapter.
- Returning `''` is documented to make CRS IP rules no-op (advisory only), which is the safer behaviour than firing false positives against `'undefined'`.

## Test plan

- [x] `@coraza/next` — `issue #27: extractClientIp lets the consumer pick the IP source` (asserts the WAF receives the `cf-connecting-ip` value the function returned, even with XFF set)
- [x] `@coraza/next` — `issue #27: default extractor still uses first XFF hop (no regression)` (locks the default behaviour)
- [x] `@coraza/next` — `issue #27: extractClientIp can return "" (no IP) and CRS IP rules become advisory`
- [x] All pre-existing tests pass (25 next tests)

## Security impact

**Improves detection accuracy.** Previously every deployment behind ALB / Nginx silently had broken IP-allowlist / scanner-detection rules with no path to fix it short of forking the runner. No new bypass surface — `extractClientIp` only widens consumer choice over `remoteAddr`; the WAF still enforces every other rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)