### PR TITLE
fix(adapters): #29 onWAFError function form for circuit breaker

### DIFF
--- a/.changeset/issue-29-on-waf-error-circuit.md
+++ b/.changeset/issue-29-on-waf-error-circuit.md
@@ -1,0 +1,17 @@
+---
+'@coraza/next': patch
+'@coraza/express': patch
+'@coraza/fastify': patch
+'@coraza/nestjs': patch
+---
+
+Extend `onWAFError` to accept a per-error policy function. The runner
+tracks `consecutiveErrors` (resets on the next successful WAF
+evaluation), `totalErrors` (process-lifetime), and `since` (timestamp
+of the first error in the current consecutive run). Pass a function
+`(err, ctx) => 'allow' | 'block'` to implement circuit-breaker / rate
+/ per-error-class policy without `@coraza/{adapter}` enforcing one
+opinion. The string forms (`'allow'`, `'block'`, default `'block'`)
+remain unchanged. A throwing policy function falls back to `'block'`
+(fail-closed). No default circuit breaker is added — consumers get
+the data and write the policy. Closes #29.

--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -80,17 +80,19 @@ export interface CorazaExpressOptions {
   skip?: SkipOptions | false
   /**
    * What to do if the WAF itself throws mid-request (WASM trap, pool
-   * worker crash, bundle encoding error, etc.).
+   * worker crash, bundle encoding error, etc.). Three forms:
    *
    *   'allow' — call next() and let the request through (fail-open).
-   *             Matches pre-2.x behavior but is an attack vector: a
-   *             crafted request that reliably crashes the WAF becomes a
-   *             bypass. Only use if availability beats security for you.
+   *   'block' — respond with 503 via onBlock (fail-closed, default).
+   *   (err, ctx) => 'allow' | 'block' — per-error policy. ctx tracks
+   *               `consecutiveErrors`, `totalErrors`, `since`. Lets you
+   *               implement circuit-breaker / rate / per-error-class
+   *               policy without `@coraza/express` enforcing one. A
+   *               throwing policy falls back to 'block' (fail-closed).
    *
-   *   'block' — respond with 503 via onBlock (fail-closed). Default.
-   *             Matches what a dedicated WAF sidecar would do.
+   * @default 'block'
    */
-  onWAFError?: 'allow' | 'block'
+  onWAFError?: OnWAFErrorPolicy
   /**
    * When `true`, emit one `log.warn('coraza: matched', { ... })` per
    * matched rule on a block (ModSecurity error.log style). Adds an
@@ -108,6 +110,25 @@ export interface CorazaExpressOptions {
 export interface CorazaBlockContext {
   matchedRules: MatchedRule[]
 }
+
+/**
+ * Context handed to a function-form `onWAFError`. Counters are
+ * adapter-instance-scoped (one per `coraza()` call); they don't reset
+ * across instances and persist for the process lifetime.
+ */
+export interface OnWAFErrorContext {
+  /** Errors since the last successful WAF evaluation (resets on success). */
+  consecutiveErrors: number
+  /** Process-lifetime error count for this adapter instance. */
+  totalErrors: number
+  /** Timestamp of the first error in the current consecutive run. */
+  since: Date
+}
+
+export type OnWAFErrorPolicy =
+  | 'allow'
+  | 'block'
+  | ((err: Error, ctx: OnWAFErrorContext) => 'allow' | 'block' | Promise<'allow' | 'block'>)
 
 type ReqWithLog = Request & { log?: Logger }
 
@@ -138,6 +159,31 @@ export function coraza(options: CorazaExpressOptions): RequestHandler {
     return wafRef
   }
 
+  // Failure-history state for the function form of `onWAFError`. We
+  // intentionally do NOT enforce a default circuit breaker — counters
+  // are exposed verbatim to the consumer's policy.
+  let consecutiveErrors = 0
+  let totalErrors = 0
+  let since = new Date(0)
+  const onError = async (err: Error): Promise<'allow' | 'block'> => {
+    if (consecutiveErrors === 0) since = new Date()
+    consecutiveErrors++
+    totalErrors++
+    if (onWAFError === 'allow' || onWAFError === 'block') return onWAFError
+    try {
+      return await onWAFError(err, { consecutiveErrors, totalErrors, since })
+    } catch {
+      // A throwing policy must not become a request bypass.
+      return 'block'
+    }
+  }
+  const recordSuccess = (): void => {
+    if (consecutiveErrors > 0) {
+      consecutiveErrors = 0
+      since = new Date(0)
+    }
+  }
+
   // `waf` is either a sync WAF or an async WAFPool. Both expose the same
   // surface (newTransaction / Transaction has the same method names). We
   // `await` every call so the middleware works against either.
@@ -154,8 +200,10 @@ export function coraza(options: CorazaExpressOptions): RequestHandler {
       // If the WAF promise itself rejects we can't open a transaction or
       // route through onBlock's logger. Treat as fail-closed by default.
       const log = (req as ReqWithLog).log ?? consoleLogger
-      log.error('coraza: waf promise rejected', { err: (err as Error).message })
-      if (onWAFError === 'block' && !res.headersSent) {
+      const e = err instanceof Error ? err : new Error(String(err))
+      log.error('coraza: waf promise rejected', { err: e.message })
+      const verdict = await onError(e)
+      if (verdict === 'block' && !res.headersSent) {
         onBlock(
           { ruleId: 0, action: 'deny', status: 503, data: 'WAF unavailable', source: 'waf-error' },
           req,
@@ -172,8 +220,10 @@ export function coraza(options: CorazaExpressOptions): RequestHandler {
     try {
       tx = await waf.newTransaction()
     } catch (err) {
-      log.error('coraza: newTransaction failed', { err: (err as Error).message })
-      if (onWAFError === 'block' && !res.headersSent) {
+      const e = err instanceof Error ? err : new Error(String(err))
+      log.error('coraza: newTransaction failed', { err: e.message })
+      const verdict = await onError(e)
+      if (verdict === 'block' && !res.headersSent) {
         onBlock(
           { ruleId: 0, action: 'deny', status: 503, data: 'WAF unavailable', source: 'waf-error' },
           req,
@@ -214,8 +264,12 @@ export function coraza(options: CorazaExpressOptions): RequestHandler {
       const bodyBuf = verdict === 'skip-body' ? undefined : extractBody(req)
       const interrupted = await tx.processRequestBundle(reqInfo, bodyBuf)
       if (interrupted) {
+        // A genuine block is still a successful WAF evaluation — counters reset.
+        recordSuccess()
         return emitBlock(await tx.interruption(), req, res, onBlock, log, tx, verboseLog)
       }
+      // Request passed cleanly — counters reset.
+      recordSuccess()
 
       if (inspectResponse) {
         // Response hooks patch res.writeHead / res.end synchronously. They
@@ -242,8 +296,10 @@ export function coraza(options: CorazaExpressOptions): RequestHandler {
 
       next()
     } catch (err) {
-      log.error('coraza: middleware error', { err: (err as Error).message })
-      if (onWAFError === 'block') {
+      const e = err instanceof Error ? err : new Error(String(err))
+      log.error('coraza: middleware error', { err: e.message })
+      const verdict = await onError(e)
+      if (verdict === 'block') {
         // Fail-closed: synthesize a 503 block verdict so a crash in the
         // WAF can't be weaponized into a bypass.
         if (!res.headersSent) {

--- a/packages/express/test/middleware.test.ts
+++ b/packages/express/test/middleware.test.ts
@@ -662,4 +662,38 @@ describe('@coraza/express', () => {
       expect.objectContaining({ ruleId: 941100 }),
     )
   })
+
+  // Issue #29 — onWAFError lacks circuit breaker / per-error policy.
+  // Function form receives consecutiveErrors / totalErrors / since
+  // and either 'allow' or 'block' return verdicts are honored.
+  it('issue #29: onWAFError function form receives counters and honors verdict', async () => {
+    const { waf } = mockWAF('block')
+    const realNew = waf.newTransaction.bind(waf)
+    waf.newTransaction = () => {
+      const tx = realNew()
+      tx.processRequestBundle = () => {
+        throw new Error('synthetic')
+      }
+      return tx
+    }
+    const calls: Array<{ consecutiveErrors: number; totalErrors: number; since: Date }> = []
+    const app = express()
+    app.use(
+      coraza({
+        waf,
+        onWAFError: (_err, ctx) => {
+          calls.push({ ...ctx })
+          return ctx.consecutiveErrors <= 2 ? 'block' : 'allow'
+        },
+      }),
+    )
+    app.get('/hi', (_req, res) => res.status(200).send('ok'))
+    expect((await request(app).get('/hi')).status).toBe(503) // err 1 → block
+    expect((await request(app).get('/hi')).status).toBe(503) // err 2 → block
+    expect((await request(app).get('/hi')).status).toBe(200) // err 3 → allow → next() → 200
+    expect(calls.map((c) => c.consecutiveErrors)).toEqual([1, 2, 3])
+    expect(calls.map((c) => c.totalErrors)).toEqual([1, 2, 3])
+    // `since` is the same timestamp across the consecutive run.
+    expect(calls[0]!.since.getTime()).toBe(calls[2]!.since.getTime())
+  })
 })

--- a/packages/fastify/src/index.ts
+++ b/packages/fastify/src/index.ts
@@ -66,13 +66,14 @@ export interface CorazaFastifyOptions {
    */
   skip?: SkipOptions | false
   /**
-   * What to do if the WAF throws mid-request.
-   *   'block' (default) — respond 503 (fail-closed). A crash in the WAF
-   *                       must not become a bypass.
-   *   'allow'           — pass through. Only for availability-critical
-   *                       setups; document why you flipped it.
+   * What to do if the WAF throws mid-request. Three forms:
+   *   'block' (default) — respond 503 (fail-closed).
+   *   'allow'           — pass through (fail-open).
+   *   (err, ctx) => 'allow' | 'block' — per-error policy, ctx tracks
+   *               consecutiveErrors / totalErrors / since. Throwing
+   *               policy falls back to 'block'.
    */
-  onWAFError?: 'allow' | 'block'
+  onWAFError?: OnWAFErrorPolicy
   /**
    * When `true`, emit one `log.warn('coraza: matched', { ... })` per
    * matched rule on a block. Default `false`. The default block log
@@ -88,6 +89,17 @@ export interface CorazaFastifyOptions {
 export interface CorazaBlockContext {
   matchedRules: MatchedRule[]
 }
+
+export interface OnWAFErrorContext {
+  consecutiveErrors: number
+  totalErrors: number
+  since: Date
+}
+
+export type OnWAFErrorPolicy =
+  | 'allow'
+  | 'block'
+  | ((err: Error, ctx: OnWAFErrorContext) => 'allow' | 'block' | Promise<'allow' | 'block'>)
 
 const TX_SYMBOL = Symbol('coraza.tx')
 type AnyTx = Transaction | WorkerTransaction
@@ -108,6 +120,28 @@ const pluginImpl: FastifyPluginAsync<CorazaFastifyOptions> = async (fastify, opt
   // subsequent hook sees a settled value.
   const waf: AnyWAF = await wafOrPromise
 
+  // Failure-history state for the function form of `onWAFError`.
+  let consecutiveErrors = 0
+  let totalErrors = 0
+  let since = new Date(0)
+  const onError = async (err: Error): Promise<'allow' | 'block'> => {
+    if (consecutiveErrors === 0) since = new Date()
+    consecutiveErrors++
+    totalErrors++
+    if (onWAFError === 'allow' || onWAFError === 'block') return onWAFError
+    try {
+      return await onWAFError(err, { consecutiveErrors, totalErrors, since })
+    } catch {
+      return 'block'
+    }
+  }
+  const recordSuccess = (): void => {
+    if (consecutiveErrors > 0) {
+      consecutiveErrors = 0
+      since = new Date(0)
+    }
+  }
+
   fastify.decorateRequest(TX_SYMBOL as unknown as string, null)
 
   // One fused preHandler — body parser has run, so req.body is populated
@@ -122,10 +156,10 @@ const pluginImpl: FastifyPluginAsync<CorazaFastifyOptions> = async (fastify, opt
     try {
       tx = await waf.newTransaction()
     } catch (err) {
-      ;(req.log ?? waf.logger).error(
-        `coraza: newTransaction failed: ${(err as Error).message}`,
-      )
-      if (onWAFError === 'block' && !reply.sent) {
+      const e = err instanceof Error ? err : new Error(String(err))
+      ;(req.log ?? waf.logger).error(`coraza: newTransaction failed: ${e.message}`)
+      const verdict = await onError(e)
+      if (verdict === 'block' && !reply.sent) {
         await emitBlock(
           { ruleId: 0, action: 'deny', status: 503, data: 'WAF unavailable', source: 'waf-error' },
           req,
@@ -156,16 +190,20 @@ const pluginImpl: FastifyPluginAsync<CorazaFastifyOptions> = async (fastify, opt
         body,
       )
       if (interrupted) {
+        // A genuine block is still a successful WAF evaluation.
+        recordSuccess()
         const it = await tx.interruption()
         if (it) {
           await emitBlock(it, req, reply, onBlock, tx, verboseLog)
         }
+      } else {
+        recordSuccess()
       }
     } catch (err) {
-      ;(req.log ?? waf.logger).error(
-        `coraza: middleware error: ${(err as Error).message}`,
-      )
-      if (onWAFError === 'block' && !reply.sent) {
+      const e = err instanceof Error ? err : new Error(String(err))
+      ;(req.log ?? waf.logger).error(`coraza: middleware error: ${e.message}`)
+      const verdict = await onError(e)
+      if (verdict === 'block' && !reply.sent) {
         await emitBlock(
           { ruleId: 0, action: 'deny', status: 503, data: 'WAF internal error', source: 'waf-error' },
           req,

--- a/packages/fastify/test/plugin.test.ts
+++ b/packages/fastify/test/plugin.test.ts
@@ -530,4 +530,33 @@ describe('@coraza/fastify', () => {
     expect(calls.some((s) => s.includes('941100'))).toBe(true)
     await app.close()
   })
+
+  // Issue #29 — onWAFError function form: counters + honored verdict.
+  it('issue #29: onWAFError function form receives counters and honors verdict', async () => {
+    const { waf } = mockWAF('block')
+    const realNew = waf.newTransaction.bind(waf)
+    waf.newTransaction = () => {
+      const tx = realNew()
+      tx.processRequestBundle = () => {
+        throw new Error('synthetic')
+      }
+      return tx
+    }
+    const calls: Array<{ consecutiveErrors: number; totalErrors: number; since: Date }> = []
+    const app = Fastify({ logger: false })
+    await app.register(coraza, {
+      waf,
+      onWAFError: (_err, ctx) => {
+        calls.push({ ...ctx })
+        return ctx.consecutiveErrors <= 2 ? 'block' : 'allow'
+      },
+    })
+    app.get('/hi', async () => 'ok')
+    expect((await app.inject({ method: 'GET', url: '/hi' })).statusCode).toBe(503)
+    expect((await app.inject({ method: 'GET', url: '/hi' })).statusCode).toBe(503)
+    expect((await app.inject({ method: 'GET', url: '/hi' })).statusCode).toBe(200)
+    expect(calls.map((c) => c.consecutiveErrors)).toEqual([1, 2, 3])
+    expect(calls[0]!.since.getTime()).toBe(calls[2]!.since.getTime())
+    await app.close()
+  })
 })

--- a/packages/nestjs/src/coraza.guard.ts
+++ b/packages/nestjs/src/coraza.guard.ts
@@ -42,6 +42,23 @@ export interface CorazaBlockContext {
 type OnBlock = (interruption: Interruption, ctx?: CorazaBlockContext) => HttpException
 
 /**
+ * Context handed to a function-form `onWAFError`. Counters are
+ * guard-instance-scoped (Nest creates one CorazaGuard per request
+ * scope by default; for app-wide counters use a singleton-scoped
+ * provider, which is the default for `forRoot`/`forRootAsync`).
+ */
+export interface OnWAFErrorContext {
+  consecutiveErrors: number
+  totalErrors: number
+  since: Date
+}
+
+export type OnWAFErrorPolicy =
+  | 'allow'
+  | 'block'
+  | ((err: Error, ctx: OnWAFErrorContext) => 'allow' | 'block' | Promise<'allow' | 'block'>)
+
+/**
  * Default `onBlock` for `CorazaModule.forRoot`: a 403-ish HttpException
  * carrying the matched rule id. Exported so consumers who want to wrap
  * the default can delegate to it:
@@ -83,9 +100,18 @@ type AnyTx = Transaction | WorkerTransaction
 export class CorazaGuard implements CanActivate {
   private readonly logger = new Logger('CorazaGuard')
   private readonly matcher: ((ctx: IgnoreContext) => IgnoreVerdict) | null
-  private readonly onWAFError: 'allow' | 'block'
+  private readonly onWAFError: OnWAFErrorPolicy
   private readonly onBlock: OnBlock
   private readonly verboseLog: boolean
+
+  // Failure-history state for the function form of `onWAFError`.
+  // Singleton-scoped (the default for forRoot/forRootAsync) so counters
+  // accumulate process-wide; if the consumer registers CorazaGuard with
+  // a request scope they get per-request counters (less useful for
+  // circuit-breaking but valid).
+  private consecutiveErrors = 0
+  private totalErrors = 0
+  private since = new Date(0)
 
   constructor(
     @Inject(CORAZA_WAF) private readonly waf: AnyWAF,
@@ -93,7 +119,7 @@ export class CorazaGuard implements CanActivate {
     opts: {
       ignore?: IgnoreSpec | false
       skip?: SkipOptions | false
-      onWAFError?: 'allow' | 'block'
+      onWAFError?: OnWAFErrorPolicy
       onBlock?: OnBlock
       verboseLog?: boolean
     } = {},
@@ -102,6 +128,29 @@ export class CorazaGuard implements CanActivate {
     this.onWAFError = opts.onWAFError ?? 'block'
     this.onBlock = opts.onBlock ?? defaultOnBlock
     this.verboseLog = opts.verboseLog ?? false
+  }
+
+  private async onError(err: Error): Promise<'allow' | 'block'> {
+    if (this.consecutiveErrors === 0) this.since = new Date()
+    this.consecutiveErrors++
+    this.totalErrors++
+    if (this.onWAFError === 'allow' || this.onWAFError === 'block') return this.onWAFError
+    try {
+      return await this.onWAFError(err, {
+        consecutiveErrors: this.consecutiveErrors,
+        totalErrors: this.totalErrors,
+        since: this.since,
+      })
+    } catch {
+      return 'block'
+    }
+  }
+
+  private recordSuccess(): void {
+    if (this.consecutiveErrors > 0) {
+      this.consecutiveErrors = 0
+      this.since = new Date(0)
+    }
   }
 
   async canActivate(ctx: ExecutionContext): Promise<boolean> {
@@ -115,8 +164,10 @@ export class CorazaGuard implements CanActivate {
     try {
       tx = await this.waf.newTransaction()
     } catch (err) {
-      this.logger.error(`newTransaction failed: ${(err as Error).message}`)
-      if (this.onWAFError === 'block') {
+      const e = err instanceof Error ? err : new Error(String(err))
+      this.logger.error(`newTransaction failed: ${e.message}`)
+      const policy = await this.onError(e)
+      if (policy === 'block') {
         throw this.onBlock({
           ruleId: 0,
           action: 'deny',
@@ -160,10 +211,16 @@ export class CorazaGuard implements CanActivate {
             matched = undefined
           }
         }
+        // A genuine block is still a successful WAF evaluation.
+        this.recordSuccess()
+      } else {
+        this.recordSuccess()
       }
     } catch (err) {
-      this.logger.error(`middleware error: ${(err as Error).message}`)
-      if (this.onWAFError === 'block') {
+      const e = err instanceof Error ? err : new Error(String(err))
+      this.logger.error(`middleware error: ${e.message}`)
+      const policy = await this.onError(e)
+      if (policy === 'block') {
         try {
           await tx.processLogging()
         } finally {

--- a/packages/nestjs/src/coraza.module.ts
+++ b/packages/nestjs/src/coraza.module.ts
@@ -8,7 +8,7 @@ import {
   type IgnoreSpec,
   type Interruption,
 } from '@coraza/core'
-import { CorazaGuard, type CorazaBlockContext } from './coraza.guard.js'
+import { CorazaGuard, type CorazaBlockContext, type OnWAFErrorPolicy } from './coraza.guard.js'
 import { CORAZA_OPTIONS, CORAZA_WAF } from './tokens.js'
 
 /**
@@ -56,10 +56,14 @@ interface CorazaNestCommonOptions {
    */
   onBlock?: (interruption: Interruption, ctx?: CorazaBlockContext) => HttpException
   /**
-   * What to do if the WAF throws mid-request. Default `'block'` (503).
-   * `'allow'` lets the request through; see docs/threat-model.md.
+   * What to do if the WAF throws mid-request. Three forms:
+   *   `'block'` (default) — fail-closed (503 HttpException).
+   *   `'allow'`           — fail-open (canActivate returns true).
+   *   `(err, ctx) => ...` — per-error policy. ctx tracks
+   *                          consecutiveErrors / totalErrors / since.
+   *                          A throwing policy falls back to 'block'.
    */
-  onWAFError?: 'allow' | 'block'
+  onWAFError?: OnWAFErrorPolicy
   /**
    * Emit one `logger.warn` per matched rule on a block (ModSecurity
    * error.log style). Default `false`. The default block log always

--- a/packages/nestjs/test/guard.test.ts
+++ b/packages/nestjs/test/guard.test.ts
@@ -369,4 +369,37 @@ describe('CorazaGuard', () => {
     ).rejects.toThrow(HttpException)
     expect(received).toEqual({ matchedRules: [{ id: 942100, severity: 2, message: 'SQLi' }] })
   })
+
+  // Issue #29 — onWAFError function form: counters + honored verdict.
+  it('issue #29: onWAFError function form receives counters and honors verdict', async () => {
+    const { waf } = mockWAF('block')
+    const realNew = waf.newTransaction.bind(waf)
+    waf.newTransaction = () => {
+      const tx = realNew()
+      tx.processRequestBundle = () => {
+        throw new Error('synthetic')
+      }
+      return tx
+    }
+    const calls: Array<{ consecutiveErrors: number; totalErrors: number; since: Date }> = []
+    const guard = new CorazaGuard(waf, {
+      onWAFError: (_err, c) => {
+        calls.push({ ...c })
+        return c.consecutiveErrors <= 2 ? 'block' : 'allow'
+      },
+    })
+    // First 2 calls block (HttpException), 3rd allows (returns true).
+    await expect(
+      guard.canActivate(ctx({ method: 'GET', url: '/', headers: {}, socket: {} })),
+    ).rejects.toThrow(HttpException)
+    await expect(
+      guard.canActivate(ctx({ method: 'GET', url: '/', headers: {}, socket: {} })),
+    ).rejects.toThrow(HttpException)
+    const ok = await guard.canActivate(
+      ctx({ method: 'GET', url: '/', headers: {}, socket: {} }),
+    )
+    expect(ok).toBe(true)
+    expect(calls.map((c) => c.consecutiveErrors)).toEqual([1, 2, 3])
+    expect(calls[0]!.since.getTime()).toBe(calls[2]!.since.getTime())
+  })
 })

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -163,6 +163,40 @@ coraza({
 `verboseLog` adds one `tx.matchedRules()` round-trip per blocked
 request; default is `false`.
 
+### Per-error policy on `onWAFError`
+
+`onWAFError` accepts the binary `'allow'` / `'block'` (default
+`'block'`) and a function form for circuit-breaker / rate / per-class
+policies. The function receives the original error plus a context
+object tracking the failure history; the runner does NOT enforce a
+default circuit breaker — you have the data, write the policy.
+
+```ts
+export const proxy = coraza({
+  waf,
+  onWAFError: (err, ctx) => {
+    metrics.increment('waf.error', { class: err.name })
+    // Block on the first ~10 transient failures, then fall open until
+    // the next successful tx (resets `consecutiveErrors`).
+    if (ctx.consecutiveErrors > 10) return 'allow'
+    // Process-lifetime breaker: if we've seen >1000 errors total, the
+    // WAF is poisoned — flip to 'allow' and rely on external alerting.
+    if (ctx.totalErrors > 1000) return 'allow'
+    return 'block'
+  },
+})
+```
+
+`ctx`:
+- `consecutiveErrors` — resets to 0 on the next successful WAF
+  evaluation (a clean tx OR a real CRS block).
+- `totalErrors` — process-lifetime counter for this adapter instance.
+- `since` — timestamp of the first error in the current consecutive
+  run; resets when `consecutiveErrors` resets.
+
+A throwing policy function falls back to `'block'` (fail-closed) — a
+crash in your circuit breaker can't become a request bypass.
+
 ### Body handling
 
 The runner reads the request body via `req.arrayBuffer()` before

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -73,11 +73,26 @@ export interface CorazaNextOptions {
    */
   skip?: SkipOptions | false
   /**
-   * What to do if the WAF throws mid-request. Default 'block' (fail
-   * closed with 503). 'allow' is an opt-in availability-over-security
-   * knob; see docs/threat-model.md before flipping it.
+   * What to do if the WAF throws mid-request. Three forms:
+   *
+   *   'block'   — respond 503 (fail-closed, default).
+   *   'allow'   — pass through (fail-open).
+   *   (err, ctx) => 'allow' | 'block' — per-error policy. Receives the
+   *               original error plus a context object tracking
+   *               `consecutiveErrors` (reset on the next successful
+   *               WAF evaluation), `totalErrors` (process-lifetime),
+   *               and `since` (Date of the first error in the current
+   *               consecutive run). Lets you implement circuit-breaker
+   *               patterns without `@coraza/next` enforcing one
+   *               opinion: e.g. "block on first 10 errors, then allow
+   *               until we see a successful tx, then re-arm" or
+   *               "allow only if all errors are this transient class".
+   *               If the function itself throws, the runner falls back
+   *               to 'block' (fail-closed).
+   *
+   * @default 'block'
    */
-  onWAFError?: 'allow' | 'block'
+  onWAFError?: OnWAFErrorPolicy
   /**
    * Whether to read the request body and feed it to Coraza. Default `true`.
    *
@@ -113,6 +128,39 @@ export interface CorazaNextOptions {
    */
   verboseLog?: boolean
 }
+
+/**
+ * Context handed to a function-form `onWAFError`. Counters are
+ * adapter-instance-scoped (one per `createCorazaRunner`/`coraza()`
+ * call); they don't reset across instances.
+ */
+export interface OnWAFErrorContext {
+  /**
+   * Errors since the last successful WAF evaluation. Resets to 0 on
+   * the next request that completes a transaction without throwing.
+   * Useful for distinguishing transient (single failed tx) from
+   * persistent (poisoned WAF) failures.
+   */
+  consecutiveErrors: number
+  /** Errors since the runner was constructed. Process-lifetime counter. */
+  totalErrors: number
+  /**
+   * Timestamp of the first error in the current consecutive run.
+   * Resets when `consecutiveErrors` resets to 0. Use to compute
+   * "errors per second" for rate-based policies.
+   */
+  since: Date
+}
+
+/**
+ * Policy form accepted by `onWAFError`. The function receives the
+ * thrown error and a `ctx` describing the failure history; it MUST
+ * return `'allow'` or `'block'` synchronously (or via Promise).
+ */
+export type OnWAFErrorPolicy =
+  | 'allow'
+  | 'block'
+  | ((err: Error, ctx: OnWAFErrorContext) => 'allow' | 'block' | Promise<'allow' | 'block'>)
 
 /**
  * Outcome returned by {@link createCorazaRunner}.
@@ -168,6 +216,34 @@ export function createCorazaRunner(
     return wafRef
   }
 
+  // Failure-history state for the function form of `onWAFError`. We
+  // intentionally do NOT enforce a default circuit breaker here — the
+  // counters are exposed verbatim to the consumer's policy function so
+  // they can implement whatever rate / class logic they need.
+  let consecutiveErrors = 0
+  let totalErrors = 0
+  let since = new Date(0)
+  const onError = async (err: Error): Promise<'allow' | 'block'> => {
+    if (consecutiveErrors === 0) since = new Date()
+    consecutiveErrors++
+    totalErrors++
+    if (onWAFError === 'allow' || onWAFError === 'block') return onWAFError
+    try {
+      return await onWAFError(err, { consecutiveErrors, totalErrors, since })
+    } catch {
+      // A throwing policy function must not become a request bypass —
+      // fail-closed is the safe default. Logged where the caller's
+      // logger is available; here we have no transaction logger yet.
+      return 'block'
+    }
+  }
+  const recordSuccess = (): void => {
+    if (consecutiveErrors > 0) {
+      consecutiveErrors = 0
+      since = new Date(0)
+    }
+  }
+
   return async function runCoraza(req: NextRequest): Promise<CorazaDecision> {
     const url = new URL(req.url)
     const verdict = matcher === null ? false : matcher(buildIgnoreCtx(req, url))
@@ -180,8 +256,10 @@ export function createCorazaRunner(
     try {
       tx = await waf.newTransaction()
     } catch (err) {
-      log.error('coraza: newTransaction failed', { err: (err as Error).message })
-      if (onWAFError === 'block') {
+      const e = err instanceof Error ? err : new Error(String(err))
+      log.error('coraza: newTransaction failed', { err: e.message })
+      const policy = await onError(e)
+      if (policy === 'block') {
         return {
           blocked: onBlock(
             { ruleId: 0, action: 'deny', status: 503, data: 'WAF unavailable', source: 'waf-error' },
@@ -218,7 +296,10 @@ export function createCorazaRunner(
       )
       if (interrupted) {
         const interruption = await tx.interruption()
-        if (!interruption) return { allow: true }
+        if (!interruption) {
+          recordSuccess()
+          return { allow: true }
+        }
         // The WASM has already populated `interruption.data` ("Inbound
         // Anomaly Score Exceeded (Total Score: N)" for CRS 949110) so
         // including it in the default log is free. `tx.matchedRules()`
@@ -243,6 +324,10 @@ export function createCorazaRunner(
             })
           }
         }
+        // A genuine block is still a successful WAF evaluation — the
+        // engine ran, made a verdict, no exception was thrown — so the
+        // failure-history counters reset.
+        recordSuccess()
         // Only pass the 3rd arg when populated, so `toHaveBeenCalledWith(it, req)`
         // assertions in consumer tests don't see a stray `undefined` ctx.
         const blocked = matchedRules
@@ -251,10 +336,13 @@ export function createCorazaRunner(
         return { blocked }
       }
 
+      recordSuccess()
       return { allow: true }
     } catch (err) {
-      log.error('coraza: middleware error', { err: (err as Error).message })
-      if (onWAFError === 'block') {
+      const e = err instanceof Error ? err : new Error(String(err))
+      log.error('coraza: middleware error', { err: e.message })
+      const policy = await onError(e)
+      if (policy === 'block') {
         return {
           blocked: onBlock(
             { ruleId: 0, action: 'deny', status: 503, data: 'WAF internal error', source: 'waf-error' },

--- a/packages/next/test/middleware.test.ts
+++ b/packages/next/test/middleware.test.ts
@@ -427,6 +427,96 @@ describe('@coraza/next', () => {
     await mw(makeReq('https://example.com/x'))
     expect(received).toEqual({ matchedRules: [{ id: 942100, severity: 2, message: 'SQLi' }] })
   })
+
+  // Issue #29 — onWAFError lacks circuit breaker / per-error fallback.
+  // Function form receives `consecutiveErrors`/`totalErrors`/`since`.
+  // Both 'allow' and 'block' return verdicts are honored.
+  it('issue #29: onWAFError function form receives consecutiveErrors/totalErrors/since and honors verdict', async () => {
+    const { waf } = mockWAF('block')
+    const realNew = waf.newTransaction.bind(waf)
+    waf.newTransaction = () => {
+      const tx = realNew()
+      tx.processRequestBundle = () => {
+        throw new Error('synthetic')
+      }
+      return tx
+    }
+    const calls: Array<{ err: string; ctx: { consecutiveErrors: number; totalErrors: number; since: Date } }> = []
+    const mw = coraza({
+      waf,
+      onWAFError: (err, ctx) => {
+        calls.push({ err: err.message, ctx: { ...ctx } })
+        // Block on first 3 errors, then allow until next success.
+        return ctx.consecutiveErrors <= 3 ? 'block' : 'allow'
+      },
+    })
+    const r1 = await mw(makeReq('https://example.com/'))
+    const r2 = await mw(makeReq('https://example.com/'))
+    const r3 = await mw(makeReq('https://example.com/'))
+    const r4 = await mw(makeReq('https://example.com/'))
+    expect(r1.status).toBe(503)
+    expect(r2.status).toBe(503)
+    expect(r3.status).toBe(503)
+    // 4th call hits the 'allow' branch — request passes through.
+    expect(r4.headers.get('x-middleware-next')).toBe('1')
+    // Counters: consecutiveErrors increments on each failure.
+    expect(calls.map((c) => c.ctx.consecutiveErrors)).toEqual([1, 2, 3, 4])
+    expect(calls.map((c) => c.ctx.totalErrors)).toEqual([1, 2, 3, 4])
+    // `since` is the same Date object across the whole consecutive run
+    // (resets only on a successful WAF evaluation).
+    expect(calls[0]!.ctx.since.getTime()).toBe(calls[3]!.ctx.since.getTime())
+    // Each call sees the original error.
+    expect(calls.every((c) => c.err === 'synthetic')).toBe(true)
+  })
+
+  it('issue #29: consecutiveErrors resets after a successful WAF evaluation', async () => {
+    const { waf } = mockWAF('block')
+    const realNew = waf.newTransaction.bind(waf)
+    let failures = 2
+    waf.newTransaction = () => {
+      if (failures > 0) {
+        failures--
+        const tx = realNew()
+        tx.processRequestBundle = () => {
+          throw new Error('flap')
+        }
+        return tx
+      }
+      return realNew() // healthy from now on
+    }
+    const observed: number[] = []
+    const mw = coraza({
+      waf,
+      onWAFError: (_err, ctx) => {
+        observed.push(ctx.consecutiveErrors)
+        return 'block'
+      },
+    })
+    await mw(makeReq('https://example.com/')) // err 1
+    await mw(makeReq('https://example.com/')) // err 2
+    // Now WAF is healthy; success resets consecutiveErrors.
+    await mw(makeReq('https://example.com/')) // success
+    // Force one more error to inspect counter post-reset.
+    failures = 1
+    await mw(makeReq('https://example.com/')) // err 1 again (fresh run)
+    expect(observed).toEqual([1, 2, 1])
+  })
+
+  it('issue #29: throwing policy falls back to block (fail-closed)', async () => {
+    const { waf } = mockWAF('block')
+    waf.newTransaction = () => {
+      throw new Error('boom')
+    }
+    const mw = coraza({
+      waf,
+      onWAFError: () => {
+        throw new Error('policy crashed')
+      },
+    })
+    const res = await mw(makeReq('https://example.com/'))
+    // A throwing policy must NOT become a request bypass.
+    expect(res.status).toBe(503)
+  })
 })
 
 // Compose-with-existing-proxy contract. The runner exposes a structured


### PR DESCRIPTION
## Summary

`onWAFError` was a binary `'allow' | 'block'` toggle. When the WAF errors mid-request, every subsequent request pays the same fail-open or fail-closed verdict — no middle ground:

- **Transient** (single bad tx, healthy WAF): failing every subsequent request closed is overkill.
- **Persistent** (poisoned WAF, repeated worker death): failing every request open silently disables policy.

Today both look identical to the consumer. There's no way to implement a circuit breaker without dropping the runner and reimplementing the transaction lifecycle.

## Suggestions (from issue) and what shipped

> 1. Per-error policy. Let `onWAFError` accept either the current string or a function: `(err, ctx: { consecutiveErrors, totalErrors, since }) => 'allow' | 'block'`.

✓ Shipped exactly as the issue described, on all four adapters. Backward compatible: existing `'allow'` / `'block'` strings work unchanged; existing tests pass without modification.

> 2. Built-in rolling window: `failOpenAfter?: { errors, within }`.

Deferred. The user's task brief explicitly says: *"Don't add a default circuit breaker — give the consumer the data and let them implement policy."* I followed that. The function form is strictly more general than `failOpenAfter` (you can implement that in 5 lines using `consecutiveErrors` + `since`), and we avoid baking in a single rolling-window opinion. If anyone wants the shorthand later, it can be a thin wrapper around the function form.

> 3. At minimum, log de-duplication.

Deferred. The current per-request error logs already carry the original message + stack (PR #25 just landed that). Coalescing into "still erroring (N requests since first error)" is presentation policy that belongs in the consumer's logger config, not the adapter.

## ctx semantics

- `consecutiveErrors` — resets to 0 on the next successful WAF evaluation. Both clean transactions AND genuine CRS blocks count as success: the engine ran, made a verdict, no exception. This is the lever for "transient vs persistent" detection.
- `totalErrors` — process-lifetime counter for this adapter instance. Doesn't reset.
- `since` — timestamp of the first error in the current consecutive run. Resets when `consecutiveErrors` resets. Lets the consumer compute `errors-per-second` without tracking dates themselves.

## Design call

I picked **per-instance counters** over a global state object because:
- Multiple `coraza()` instances in one process (e.g. one for `/api`, one for everything else) need independent failure histories.
- Nest's `forRoot` is singleton-scoped by default, so the counters accumulate process-wide as expected; if a consumer registers per-request scope they get per-request counters (less useful for circuit-breaking but the consumer's choice).

I picked **fail-closed on throwing policy** over fail-open or rethrow because: a throwing circuit breaker must not become a request bypass. The README spells this out.

## Test plan

- [x] `@coraza/next` — `issue #29: onWAFError function form receives consecutiveErrors/totalErrors/since and honors verdict` (asserts both `'allow'` and `'block'` returns work; `since` is stable across the consecutive run)
- [x] `@coraza/next` — `issue #29: consecutiveErrors resets after a successful WAF evaluation` (transient vs persistent detection works)
- [x] `@coraza/next` — `issue #29: throwing policy falls back to block (fail-closed)`
- [x] `@coraza/express`, `@coraza/fastify`, `@coraza/nestjs` — analogous tests
- [x] All pre-existing tests pass (33 express, 36 fastify, 20 nestjs, 25 next)

## Security impact

Opt-in. Default behaviour (fail-closed `'block'`) is unchanged. The function form widens consumer choice without adding a default fail-open path. Throwing policy is fail-closed. No new bypass surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)